### PR TITLE
Added test for direct dependency licenses

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "node": ">=0.10"
   },
   "devDependencies": {
+    "async": "^2.1.4",
     "aws-sdk": "^2.7.0",
     "eslint": "^3.9.1",
     "segfault-handler": "^1.0.0",

--- a/tests/.eslintrc
+++ b/tests/.eslintrc
@@ -5,7 +5,7 @@
   "rules": {
     "max-nested-callbacks": "off",
     "func-names": "off",
-    "no-shadow": ["warn", {"allow": ["t", "shim", "error", "err"]}],
+    "no-shadow": ["warn", {"allow": ["cb", "t", "shim", "error", "err"]}],
     "brace-style": ["error", "1tbs", {"allowSingleLine": true}]
   }
 }

--- a/tests/unit/licenses.tap.js
+++ b/tests/unit/licenses.tap.js
@@ -1,0 +1,48 @@
+'use strict'
+
+var a = require('async')
+var fs = require('fs')
+var path = require('path')
+var pkg = require('../../package')
+var tap = require('tap')
+
+
+var MODULE_DIR = path.resolve(__dirname, '../../node_modules')
+var LICENSES = {
+  'nan': 'MIT',
+  'node-pre-gyp': 'BSD-3-Clause'
+}
+
+
+tap.test('Dependency licenses', function(t) {
+  var deps = Object.keys(pkg.dependencies || {})
+  deps.push.apply(deps, Object.keys(pkg.optionalDependencies || {}))
+  a.map(deps, function(dep, cb) {
+    a.waterfall([
+      function(cb) {
+        fs.readFile(path.join(MODULE_DIR, dep, 'package.json'), {encoding: 'utf8'}, cb)
+      },
+      function(depPackage, cb) {
+        try {
+          var parsedPackage = JSON.parse(depPackage)
+          var license = parsedPackage.license || parsedPackage.licenses
+          process.nextTick(function() {
+            cb(null, [dep, license])
+          })
+        } catch (e) {
+          cb(e)
+        }
+      }
+    ], cb)
+  }, function(err, depLicensesArray) {
+    if (t.error(err, 'should not fail to retrieve licenses')) {
+      var depLicenses = depLicensesArray.reduce(function(obj, dep) {
+        obj[dep[0]] = dep[1]
+        return obj
+      }, {})
+
+      t.deepEqual(depLicenses, LICENSES, 'should have expected licenses')
+    }
+    t.end()
+  })
+})


### PR DESCRIPTION
Previously we relied on the agent's license test to assert this module's licenses as well. After refactoring the agent's license test it no longer did that, so I've added a license test to this module too.