### PR TITLE
Release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### v0.1.1 (2016-12-05):
+
+* Added guard against binding GC events more than once.
+
+* Removed OS X from Travis to temporarily get around extremely long builds.
+  Added script to run tests locally across multiple versions of Node.
+
+* Added test for checking licenses of dependencies.
 
 ### v0.1.0 (2016-11-29):
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@newrelic/native-metrics",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A module for generating metrics from V8.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Release notes:

* Added guard against binding GC events more than once.

* Removed OS X from Travis to temporarily get around extremely long builds.
  Added script to run tests locally across multiple versions of Node.

* Added test for checking licenses of dependencies.