### PR TITLE
Remove preinstall hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "A module for generating metrics from V8.",
   "main": "index.js",
   "scripts": {
-    "preinstall": "npm install node-pre-gyp",
     "install": "node-pre-gyp install --fallback-to-build",
     "lint": "eslint ./*.js lib",
     "unit": "tap --expose-gc tests/**/*.tap.js",


### PR DESCRIPTION
Preinstall hooks are triggered even when this library is being consumed by another package, which would install `node-pre-gyp` into that project's dependencies.

This also has the extra implication that shrinkwrapping that project would then fail due to extraneous installed dependency which is not listed in the project's *package.json*.

Installing the project either as a dependency or when working on it directly still works even without the preinstall hook.

Thanks for review and merging!