### PR TITLE
Remove pre-install, add bundled dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "remote_path": "./nodejs_agent/builds"
   },
   "engines": {
-    "node": ">=0.12"
+    "node": ">=0.12",
+    "npm": ">=2"
   },
   "devDependencies": {
     "async": "^2.1.4",
@@ -55,5 +56,8 @@
   "dependencies": {
     "nan": "^2.4.0",
     "node-pre-gyp": "^0.6.31"
-  }
+  },
+  "bundledDependencies": [
+    "node-pre-gyp"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "A module for generating metrics from V8.",
   "main": "index.js",
   "scripts": {
-    "preinstall": "npm install node-pre-gyp",
     "install": "node-pre-gyp install --fallback-to-build",
     "lint": "eslint ./*.js lib",
     "unit": "tap --expose-gc tests/**/*.tap.js",


### PR DESCRIPTION
The node-pre-gyp package is necessary for our installation process in order to provide pre-built binaries but interferes with the dependencies of the parent project. Unfortunately, there is also potential for a race condition in npm 2 when resolving dependencies that could mean it is not yet installed during our 'install' script. Until we can drop Node 4 from our supported versions we must keep this as a bundled dep.

Closes #10
