### PR TITLE
Removed 0.10 from supported versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
   - "0.12"
   - "4"
   - "5"

--- a/README.md
+++ b/README.md
@@ -12,10 +12,9 @@ goal is to use it with that package, there is nothing that needs to be done.
 `npm install @newrelic/native-metrics`
 
 Note that this is a native module and thus must be compiled to function. We
-provide pre-built Linux binaries for Node v0.10, v0.12, and v4-v7. If you are
-not using Linux, or are using a version of Node other than we've listed above
-you will need to have a compiler installed on the machine where this is to be
-deployed.
+provide pre-built Linux binaries for Node v0.12, and v4-v7. If you are not using
+Linux, or are using a version of Node other than we've listed above you will
+need to have a compiler installed on the machine where this is to be deployed.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "remote_path": "./nodejs_agent/builds"
   },
   "engines": {
-    "node": ">=0.10"
+    "node": ">=0.12"
   },
   "devDependencies": {
     "async": "^2.1.4",


### PR DESCRIPTION
Our tests are no longer able to compile and run on 0.10. Without functioning tests we can not support the version anymore.