### PR TITLE
Metric timers prevent process from stopping

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ NativeMetricEmitter.prototype.bind = function bind(timeout) {
   this._gcBinder.bind()
   this._loopChecker.bind()
 
-  this._timeout = setTimeout(nativeMetricTimeout.bind(this), timeout)
+  this._timeout = setTimeout(nativeMetricTimeout.bind(this), timeout).unref()
   function nativeMetricTimeout() {
     if (this._rusageMeter) {
       /**
@@ -152,7 +152,7 @@ NativeMetricEmitter.prototype.bind = function bind(timeout) {
       this.emit('usage', this._rusageMeter.read())
     }
     if (this.bound) {
-      this._timeout = setTimeout(nativeMetricTimeout.bind(this), timeout)
+      this._timeout = setTimeout(nativeMetricTimeout.bind(this), timeout).unref()
     }
   }
 


### PR DESCRIPTION
The timers used by the `NativeMetricEmitter` are preventing normal process stopping because node is waiting on them to finish, which they never do since each one triggers the next timer. This is evident when running tests in an application with the newrelic agent included.