### PR TITLE
This is an ISSUE actually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### v2.1.0 (2017-02-06):
+
+* Added an event loop CPU usage metric.
+
+  The module will now report round trip CPU usage metrics for Node's event loop. This
+  metric can be read off with `nativeMetrics.getLoopMetrics()` and will
+  represent the amount of CPU time per tick of the event loop.
+
 ### v2.0.2 (2017-01-19):
 
 * Removed pre-compiling binaries using the `node-pre-gyp` module.


### PR DESCRIPTION
Hey, 

Sorry for the confusion, I'm just trying to ask a question about the usage of this.

For `loopMetrics`, does `count` represents the number of ticks happened between two meatures? If so, why the data I collected is totally different from what I saw on new relic's APM page? I meatured it every minute and the `count` is about 1000, however, the `ticks per minute` shows the actual number is about 5k.

If not, how do you collect the `ticks per minute` data?

Thanks!