### PR TITLE
Update readme loop metrics usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,11 @@ if (emitter.usageEnabled) {
 if (emitter.loopEnabled) {
   setInterval(() => {
     var loopMetrics = emitter.getLoopMetrics()
-    console.log("Loop time:", loopMetrics.loop)
-    console.log("IO wait time:", loopMetrics.ioWait)
+    console.log("Total time:", loopMetrics.usage.total)
+    console.log("Min time:", loopMetrics.usage.min)
+    console.log("Max time:", loopMetrics.usage.max)
+    console.log("Sum of squares:", loopMetrics.usage.sumOfSquares)
+    console.log("Count:", loopMetrics.usage.count)
   }, 1000)
 }
 ```


### PR DESCRIPTION
Hi!

The current example of `getLoopMetrics` return value usage in the readme doesn't match what the function actually returns (resulting in logging "Loop time: undefined:" and "IO wait time: undefined" if run as is).

This PR modifies the readme to reflect what the function returns.

Feel free to edit this PR to put a better description of each property. :)