### PR TITLE
Refactored GC metrics to act like loop metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 This module provides hooks into the native layer of Node to provide metrics for
 the [New Relic Node Agent][npm-newrelic]. It gathers information that isn't
 available at the JS layer about the V8 virtual machine and the process health.
-It comes packaged with the New Relic Agent v2, and there is nothing that needs
-to be done. For Agent v1 you need only to install the module alongside
+It comes packaged with the New Relic Agent since v2, and there is nothing that
+needs to be done. For Agent v1 you need only to install the module alongside
 [`newrelic`][npm-newrelic].
 
 ## Installation
@@ -52,7 +52,14 @@ var getMetricEmitter = require('@newrelic/native-metrics')
 
 var emitter = getMetricEmitter()
 if (emitter.gcEnabled) {
-  emitter.on('gc', (gc) => console.log(gc.type + ': ' + gc.duration))
+  setInterval(() => {
+    var gcMetrics = emitter.getGCMetrics()
+    for (var type in gcMetrics) {
+      console.log('GC type name:', type)
+      console.log('GC type id:', gcMetrics[type].typeId)
+      console.log('GC metrics:', gcMetrics[type].metrics)
+    }
+  }, 1000)
 }
 if (emitter.usageEnabled) {
   emitter.on('usage', (usage) => console.log(usage))
@@ -60,11 +67,11 @@ if (emitter.usageEnabled) {
 if (emitter.loopEnabled) {
   setInterval(() => {
     var loopMetrics = emitter.getLoopMetrics()
-    console.log("Total time:", loopMetrics.usage.total)
-    console.log("Min time:", loopMetrics.usage.min)
-    console.log("Max time:", loopMetrics.usage.max)
-    console.log("Sum of squares:", loopMetrics.usage.sumOfSquares)
-    console.log("Count:", loopMetrics.usage.count)
+    console.log('Total time:', loopMetrics.usage.total)
+    console.log('Min time:', loopMetrics.usage.min)
+    console.log('Max time:', loopMetrics.usage.max)
+    console.log('Sum of squares:', loopMetrics.usage.sumOfSquares)
+    console.log('Count:', loopMetrics.usage.count)
   }, 1000)
 }
 ```

--- a/src/GCBinder.cpp
+++ b/src/GCBinder.cpp
@@ -3,70 +3,43 @@
 
 namespace nr {
 
-struct GCResults {
-  GCResults(uint64_t d, v8::GCType t): duration(d), type(t) {}
-
-  uint64_t duration;
-  v8::GCType type;
-};
-
 GCBinder* GCBinder::_instance = NULL; // TODO: nullptr once we drop Node <4.
 
 NAN_METHOD(GCBinder::New) {
-  if (info.Length() != 1 || !info[0]->IsFunction()) {
-    return Nan::ThrowError("GC callback function is required.");
-  }
   if (_instance != NULL) {
     return Nan::ThrowError("GCBinder instance already created.");
   }
-
-  // Store the callback on the JS object so its lifetime is properly tied to
-  // the lifetime of this object.
-  v8::Local<v8::Function> onGCCallback = info[0].As<v8::Function>();
-  Nan::Set(
-    info.This(),
-    Nan::New("_onGCCallback").ToLocalChecked(),
-    onGCCallback
-  );
 
   GCBinder* obj = new GCBinder();
   obj->Wrap(info.This());
   info.GetReturnValue().Set(info.This());
 }
 
-void GCBinder::_doCallback(uv_work_t* handle, int) {
-  GCResults* res = (GCResults*)handle->data;
+NAN_METHOD(GCBinder::Read) {
+  Nan::HandleScope scope;
+  GCBinder* self = GCBinder::Unwrap<GCBinder>(info.This());
 
-  if (_instance) {
-    // Send out the gc statistics to our callback.
-    Nan::HandleScope scope;
-    v8::Local<v8::Value> args[] = {
-      Nan::New<v8::Number>((double)res->type),
-      Nan::New<v8::Number>((double)res->duration)
-    };
-    Nan::MakeCallback(
-      _instance->handle(),
-      Nan::New("_onGCCallback").ToLocalChecked(),
-      2, args
+  v8::Local<v8::Object> results = Nan::New<v8::Object>();
+  for (auto& metrics : self->_gcMetrics) {
+    // first == type, second == metrics
+    Nan::Set(
+      results,
+      Nan::New((double)metrics.first),
+      metrics.second.asJSObject()
     );
+    metrics.second.reset();
   }
 
-  delete res;
-  delete handle;
+  info.GetReturnValue().Set(results);
 }
 
-void _noopWork(uv_work_t*){}
-
 void GCBinder::_gcEnd(const v8::GCType type) {
-  // Grab our time immediately.
-  uint64_t gcEndTimeHR = uv_hrtime();
-
-  // Schedule the callback on the event loop.
-  // XXX uv_async_t causes process to hang. No idea why. uv_timer_t causes
-  // segmentation faults. No idea why. uv_work_t works, so going with that.
-  uv_work_t* handle = new uv_work_t;
-  handle->data = new GCResults(gcEndTimeHR - _gcStartTimeHR, type);
-  uv_queue_work(uv_default_loop(), handle, &_noopWork, &_doCallback);
+  // HR times are in nanoseconds. A duration of 70 milliseconds in nanoseconds
+  // would overflow a `Metric<unint64_t>`'s `sumOfSquares` field. It is entirely
+  // believable that a 70 ms GC event could occur, so we will convert everything
+  // to milliseconds and store them as doubles instead.
+  uint64_t durationHr = uv_hrtime() - _gcStartTimeHR;
+  _gcMetrics[type] += durationHr / 1000000.0; // 1 million ns per ms
 }
 
 }

--- a/src/GCBinder.hpp
+++ b/src/GCBinder.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <map>
 #include <nan.h>
+
+#include "Metric.hpp"
 
 namespace nr {
 
@@ -13,6 +16,7 @@ public:
 
     SetPrototypeMethod(clas, "bind", Bind);
     SetPrototypeMethod(clas, "unbind", Unbind);
+    SetPrototypeMethod(clas, "read", Read);
 
     constructor().Reset(Nan::GetFunction(clas).ToLocalChecked());
     Nan::Set(
@@ -37,6 +41,8 @@ public:
   static NAN_METHOD(Unbind) {
     _unbind();
   }
+
+  static NAN_METHOD(Read);
 
   GCBinder():
     _gcStartTimeHR(uv_hrtime())
@@ -80,8 +86,6 @@ private:
     return _constructor;
   }
 
-  static void _doCallback(uv_work_t* handle, int);
-
   void _gcStart() {
     _gcStartTimeHR = uv_hrtime();
   }
@@ -89,6 +93,7 @@ private:
   void _gcEnd(const v8::GCType type);
 
   uint64_t _gcStartTimeHR;
+  std::map<v8::GCType, Metric<double>> _gcMetrics;
 };
 
 }

--- a/tests/integration/server.tap.js
+++ b/tests/integration/server.tap.js
@@ -10,10 +10,6 @@ var RUN_TIME = 5 * 60 * 1000 // 5 minutes
 segs.registerHandler('crash.log')
 
 tap.test('server soak test', {timeout: RUN_TIME + 10000}, function(t) {
-  natives.on('gc', function(data) {
-    t.ok(data.type, 'should have a recognized type name')
-  })
-
   t.comment('Running test server for ' + RUN_TIME + 'ms')
   var server = http.createServer(function(req, res) {
     res.write('ok')
@@ -32,6 +28,11 @@ tap.test('server soak test', {timeout: RUN_TIME + 10000}, function(t) {
     t.comment('stopping')
     keepSending = false
   }, RUN_TIME)
+
+  setInterval(function() {
+    t.ok(natives.getGCMetrics(), 'should have readable gc metrics')
+    t.ok(natives.getLoopMetrics(), 'should have readable loop metrics')
+  }, 5000).unref()
 
   function sendRequest() {
     http.get('http://localhost:' + port, function(res) {

--- a/tests/integration/server.tap.js
+++ b/tests/integration/server.tap.js
@@ -51,8 +51,10 @@ tap.test('server soak test', {timeout: RUN_TIME + 10000}, function(t) {
       if (keepSending) {
         setTimeout(sendRequest, 10)
       } else {
-        server.close()
-        t.end()
+        server.close(function(err) {
+          t.error(err, 'should not fail to close')
+          t.end()
+        })
       }
     })
   }


### PR DESCRIPTION
The `gc` event is no more. Instead the metrics are accumulated in C++ and only copied to JS when `NativeMetricsEmitter#getGCMetrics` is called. That call will also reset the accumulated metrics, so each call is only a measure of the garbage collections since the last call.