### PR TITLE
NODE-1775 More clearly handle access error when trying to build path

### DIFF
--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -84,8 +84,11 @@ function makePath(pathToMake, cb) {
 
     fs.access(p, accessRights, function fsAccessCB(err) {
       if (!err) {
-        // It exists! Move on to the next part.
+        // It exists and we have read+write access! Move on to the next part.
         return _make(i, p, cb)
+      } else if (err.code !== 'ENOENT') {
+        // It exists but we don't have read+write access! This is a problem.
+        return cb(new Error('Do not have access to "' + p + '": ' + err))
       }
 
       // It probably does not exist, so try to make it.


### PR DESCRIPTION
Provide more clear error for case where a directory exists but we don't have write access to it.