### PR TITLE
Mod: pre-build.js to allow caching of downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ $ npm install @newrelic/native-metrics
 
 If both env vars are set, `NO_BUILD` will override `NO_DOWNLOAD`.
 
+If you are working behind a firewall and want to cache the downloads internally
+you can set the value of the download host and remote path instead of forcing a
+build:
+
+```sh
+$ export NR_NATIVE_METRICS_DOWNLOAD_HOST=http://your-internal-cache/
+$ export NR_NATIVE_METRICS_REMOTE_PATH=path/to/download/folder/
+$ npm install @newrelic/native-metrics
+```
+
 ## Usage
 
 ```js

--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -19,8 +19,13 @@ var zlib = require('zlib')
 var CPU_COUNT = os.cpus().length
 var IS_WIN = process.platform === 'win32'
 var S3_BUCKET = 'nr-downloads-main'
-var DOWNLOAD_HOST = 'https://download.newrelic.com/'
-var REMOTE_PATH = 'nodejs_agent/builds/'
+
+var DOWNLOAD_HOST = process.env.NR_NATIVE_METRICS_DOWNLOAD_HOST
+                  || 'https://download.newrelic.com/'
+
+var REMOTE_PATH = process.env.NR_NATIVE_METRICS_REMOTE_PATH
+                || 'nodejs_agent/builds/'
+
 var PACKAGE_ROOT = path.resolve(__dirname, '..')
 var BUILD_PATH = path.resolve(PACKAGE_ROOT, './build/Release')
 


### PR DESCRIPTION
This is useful for caching assets (for example in artifactory) if you
are installing behind a firewall or without public internet access.

It also means we can scan the assets and aren't trusting random binary
downloads from the open internet.