### PR TITLE
Add check if `/t:` needs to be add on windows

### DIFF
--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -18,6 +18,7 @@ var zlib = require('zlib')
 
 var CPU_COUNT = os.cpus().length
 var IS_WIN = process.platform === 'win32'
+var HAS_NEW_NODE_GYP_ARGS = process.env.versions.node >= '10.8.0'
 var S3_BUCKET = 'nr-downloads-main'
 
 var DOWNLOAD_HOST = process.env.NR_NATIVE_METRICS_DOWNLOAD_HOST
@@ -186,7 +187,7 @@ function execGyp(args, cb) {
 }
 
 function build(target, rebuild, cb) {
-  if (IS_WIN) {
+  if (IS_WIN && HAS_NEW_NODE_GYP_ARGS) {
     target = '/t:' + target
   }
 

--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -13,12 +13,13 @@ var fs = require('fs')
 var https = require('https')
 var os = require('os')
 var path = require('path')
+var semver = require('semver')
 var zlib = require('zlib')
 
 
 var CPU_COUNT = os.cpus().length
 var IS_WIN = process.platform === 'win32'
-var HAS_NEW_NODE_GYP_ARGS = process.env.versions.node >= '10.8.0'
+var HAS_NEW_NODE_GYP_ARGS = semver.gte(process.versions.node, '10.8.0')
 var S3_BUCKET = 'nr-downloads-main'
 
 var DOWNLOAD_HOST = process.env.NR_NATIVE_METRICS_DOWNLOAD_HOST

--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -19,7 +19,7 @@ var zlib = require('zlib')
 
 var CPU_COUNT = os.cpus().length
 var IS_WIN = process.platform === 'win32'
-var HAS_NEW_NODE_GYP_ARGS = semver.gte(process.versions.node, '10.8.0')
+var HAS_OLD_NODE_GYP_ARGS_FOR_WINDOWS = semver.lt(process.versions.node, '10.8.0')
 var S3_BUCKET = 'nr-downloads-main'
 
 var DOWNLOAD_HOST = process.env.NR_NATIVE_METRICS_DOWNLOAD_HOST
@@ -188,7 +188,7 @@ function execGyp(args, cb) {
 }
 
 function build(target, rebuild, cb) {
-  if (IS_WIN && HAS_NEW_NODE_GYP_ARGS) {
+  if (IS_WIN && HAS_OLD_NODE_GYP_ARGS_FOR_WINDOWS) {
     target = '/t:' + target
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4109,10 +4109,9 @@
       }
     },
     "semver": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
-      "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs=",
-      "dev": true
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
     "shebang-command": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
     "aws-sdk": "^2.266.1",
     "eslint": "^4.19.1",
     "segfault-handler": "^1.0.1",
-    "semver": "^5.5.0",
     "tap": "^12.0.1"
   },
   "dependencies": {
-    "nan": "^2.10.0"
+    "nan": "^2.10.0",
+    "semver": "^5.5.1"
   }
 }

--- a/tests/unit/licenses.tap.js
+++ b/tests/unit/licenses.tap.js
@@ -9,7 +9,8 @@ var tap = require('tap')
 
 var MODULE_DIR = path.resolve(__dirname, '../../node_modules')
 var LICENSES = {
-  'nan': 'MIT'
+  'nan': 'MIT',
+  'semver': 'ISC'
 }
 
 


### PR DESCRIPTION
From Node v10.8.0 on, node-gyp comes in v3.7.0 which will prepend it as a target. Added a check which version is used to not always add the prefix.

(check also https://stackoverflow.com/questions/51526377/the-target-tnative-metrics-does-not-exist-in-the-project/52086917 and https://discuss.newrelic.com/t/newrelic-native-metrics-does-not-install-on-windows-10-from-corrupt-vcxproj/54625/3 which looks quite similar)