### PR TITLE
Mod: download to allow http and https hosts

### DIFF
--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -10,6 +10,7 @@
 // XXX already installed. Core modules are okay.
 var cp = require('child_process')
 var fs = require('fs')
+var http = require('http')
 var https = require('https')
 var os = require('os')
 var path = require('path')
@@ -30,7 +31,6 @@ var REMOTE_PATH = process.env.NR_NATIVE_METRICS_REMOTE_PATH
 
 var PACKAGE_ROOT = path.resolve(__dirname, '..')
 var BUILD_PATH = path.resolve(PACKAGE_ROOT, './build/Release')
-
 
 var opts = {}
 exports.load = load
@@ -214,7 +214,17 @@ function download(target, cb) {
   var hasCalledBack = false
   var fileName = getPackageFileName(target)
   var url = DOWNLOAD_HOST + REMOTE_PATH + fileName
-  https.get(url, function getFile(res) {
+
+  if (DOWNLOAD_HOST.startsWith('https:')) {
+    var client = https
+  } else {
+    console.log(
+      'Falling back to http, please consider enabling SSL on ' + DOWNLOAD_HOST
+    )
+    var client = http
+  }
+
+  client.get(url, function getFile(res) {
     if (res.statusCode !== 200) {
       return cb(new Error('Failed to download ' + url + ': code ' + res.statusCode))
     }


### PR DESCRIPTION
This is useful when caching assets internally and your internal cache doesn't have https