### PR TITLE
node-gyp target argument based on its own version

### DIFF
--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -19,7 +19,7 @@ var zlib = require('zlib')
 
 var CPU_COUNT = os.cpus().length
 var IS_WIN = process.platform === 'win32'
-var HAS_OLD_NODE_GYP_ARGS_FOR_WINDOWS = semver.lt(process.versions.node, '10.8.0')
+var HAS_OLD_NODE_GYP_ARGS_FOR_WINDOWS = semver.lt(gypVersion() || '0.0.0', '3.7.0')
 var S3_BUCKET = 'nr-downloads-main'
 
 var DOWNLOAD_HOST = process.env.NR_NATIVE_METRICS_DOWNLOAD_HOST
@@ -156,6 +156,22 @@ function findNodeGyp() {
   }
 
   return null
+}
+
+function gypVersion() {
+  var cmd = null
+  var args = ['-v']
+  var gyp = findNodeGyp()
+  if (gyp) {
+    args.unshift(gyp) // push_front
+    cmd = process.execPath
+  } else {
+    cmd = IS_WIN ? 'node-gyp.cmd' : 'node-gyp'
+  }
+
+  var child = cp.spawnSync(cmd, args)
+  var match = /v(\d+\.\d+\.\d+)/.exec(child.stdout)
+  return match && match[1]
 }
 
 function execGyp(args, cb) {


### PR DESCRIPTION
Current detection of node-gyp version is based on node.js version, then the build fails on windows platform if you have a node.js version lower than 10.8.0 but a node-gyp greater or equal to 3.7.0.
This PR fix this issue by getting the actual version of node-gyp.