### PR TITLE
NODE-1945 Make failure messages a bit more friendly

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
   "env": {
     "node": true,
-    "browser": false
+    "browser": false,
+    "es6": true
   },
   "globals": {
     "Promise": true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
   - "6"
   - "7"
   - "8"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,6 @@
 # Test against the latest version of this Node.js version
 environment:
   matrix:
-    - nodejs_version: "4"
-    - nodejs_version: "5"
     - nodejs_version: "6"
     - nodejs_version: "7"
     - nodejs_version: "8"
@@ -13,9 +11,6 @@ environment:
 install:
   # Get the latest stable version of Node.js.
   - ps: Install-Product node $env:nodejs_version
-
-  # Update npm to 4 on node 5
-  - ps: if ($(node --version) -match "v5") {npm i -g npm@4}
 
   # Install modules
   - npm install

--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -374,12 +374,14 @@ function executeCli(cmd, target) {
   /* eslint-disable no-console */
   console.log(
     [
-      '============================================================================\n',
+      '============================================================================',
       `Attempting ${cmd} in native-metrics module. Please note that this is an`,
-      '\n OPTIONAL dependency, and any resultant errors in this process will not',
-      '\n affect the performance of the New Relic agent itself.',
-      '\n============================================================================\n'
-    ].join(' ')
+      ' OPTIONAL dependency, and any resultant errors in this process will not',
+      ' affect the general performance of the New Relic agent, but event loop and',
+      ' garbage collection metrics will not be collected.',
+      '============================================================================',
+      ''
+    ].join('\n')
   )
 
   if (cmd === 'build' || cmd === 'rebuild') {

--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -376,9 +376,9 @@ function executeCli(cmd, target) {
     [
       '============================================================================',
       `Attempting ${cmd} in native-metrics module. Please note that this is an`,
-      ' OPTIONAL dependency, and any resultant errors in this process will not',
-      ' affect the general performance of the New Relic agent, but event loop and',
-      ' garbage collection metrics will not be collected.',
+      'OPTIONAL dependency, and any resultant errors in this process will not',
+      'affect the general performance of the New Relic agent, but event loop and',
+      'garbage collection metrics will not be collected.',
       '============================================================================',
       ''
     ].join('\n')

--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -191,12 +191,10 @@ function execGyp(args, cb) {
   console.log('> ' + cmd + ' ' + args.join(' ')) // eslint-disable-line no-console
 
   var child = cp.spawn(cmd, args, spawnOpts)
-  child.on('error', function onGypError(err) {
-    cb(new Error('Failed to execute ' + cmd + ' ' + args.join(' ') + ': ' + err))
-  })
+  child.on('error', cb)
   child.on('close', function onGypClose(code) {
     if (code !== 0) {
-      cb(new Error('Failed to execute ' + cmd + ' ' + args.join(' ') + ': code ' + code))
+      cb(new Error('Command exited with non-zero code: ' + code))
     } else {
       cb(null)
     }
@@ -231,7 +229,9 @@ function download(target, cb) {
   var fileName = getPackageFileName(target)
   var url = DOWNLOAD_HOST + REMOTE_PATH + fileName
   https.get(url, function getFile(res) {
-    if (res.statusCode !== 200) {
+    if (res.statusCode === 404) {
+      return cb(new Error('No pre-built artifacts for your OS/architecture.'))
+    } else if (res.statusCode !== 200) {
       return cb(new Error('Failed to download ' + url + ': code ' + res.statusCode))
     }
 
@@ -246,14 +246,14 @@ function download(target, cb) {
     res.on('error', function onResError(err) {
       if (!hasCalledBack) {
         hasCalledBack = true
-        cb(new Error('Failed to download ' + url + ': ' + err))
+        cb(new Error('Failed to download ' + url + ': ' + err.message))
       }
     })
 
     unzip.on('error', function onResError(err) {
       if (!hasCalledBack) {
         hasCalledBack = true
-        cb(new Error('Failed to unzip ' + url + ': ' + err))
+        cb(new Error('Failed to unzip ' + url + ': ' + err.message))
       }
     })
 
@@ -327,7 +327,7 @@ function install(target, cb) {
   function doCallback(err) {
     if (err) {
       errors.push(err)
-      cb(new Error('Failed to install module: ' + errors.join('; ')))
+      cb(err)
     } else {
       cb()
     }
@@ -351,7 +351,7 @@ function upload(target, cb) {
     Body: zip
   }, function s3UploadCb(err) {
     if (err) {
-      cb(new Error('Failed to upload file: ' + err))
+      cb(new Error('Failed to upload file: ' + err.message))
     } else {
       cb()
     }
@@ -386,13 +386,12 @@ function executeCli(cmd, target) {
   }
 
   function _endCli(err) {
-    /* eslint-disable no-console */
     if (err) {
-      console.error(new Error('Failed to execute ' + cmd + ': ' + err).toString())
+      console.error(`Failed to execute native-metrics ${cmd}: ${err.message}`)
       process.exit(1)
     } else {
       console.log(cmd + ' successful: ' + _getFileName(target))
     }
-    /* eslint-enable no-console */
   }
+  /* eslint-enable no-console */
 }

--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -371,6 +371,17 @@ function parseArgs(_argv, _opts) {
 }
 
 function executeCli(cmd, target) {
+  /* eslint-disable no-console */
+  console.log(
+    [
+      '============================================================================\n',
+      `Attempting ${cmd} in native-metrics module. Please note that this is an`,
+      '\n OPTIONAL dependency, and any resultant errors in this process will not',
+      '\n affect the performance of the New Relic agent itself.',
+      '\n============================================================================\n'
+    ].join(' ')
+  )
+
   if (cmd === 'build' || cmd === 'rebuild') {
     build(target, cmd === 'rebuild', function buildCb(err) {
       if (err) {

--- a/package.json
+++ b/package.json
@@ -36,12 +36,17 @@
       "name": "Natalie Wolfe",
       "email": "nwolfe@newrelic.com",
       "web": "https://newrelic.com"
+    },
+    {
+      "name": "Peter Svetlichny",
+      "email": "psvetlichny@newrelic.com",
+      "web": "https://newrelic.com"
     }
   ],
   "license": "LicenseRef-LICENSE",
   "engines": {
-    "node": ">=0.12",
-    "npm": ">=2"
+    "node": ">=6",
+    "npm": ">=3"
   },
   "devDependencies": {
     "async": "^2.6.1",


### PR DESCRIPTION
* Added pre-execution log message calling out that this is an optional dependency in the agent.

* Simplified final error by removing most of the confusing `Failed to...` messages.