### PR TITLE
Allow specifying local path for .node

### DIFF
--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -66,7 +66,7 @@ function getPackageFileName(target) {
 }
 
 function load(target) {
-  if(LOCAL_PATH) {
+  if (LOCAL_PATH) {
     return require(LOCAL_PATH)
   }
   return require(path.join(BUILD_PATH, getBinFileName(target)))

--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -29,6 +29,8 @@ var DOWNLOAD_HOST = process.env.NR_NATIVE_METRICS_DOWNLOAD_HOST
 var REMOTE_PATH = process.env.NR_NATIVE_METRICS_REMOTE_PATH
                 || 'nodejs_agent/builds/'
 
+var LOCAL_PATH = process.env.NR_NATIVE_METRICS_LOCAL_PATH
+
 var PACKAGE_ROOT = path.resolve(__dirname, '..')
 var BUILD_PATH = path.resolve(PACKAGE_ROOT, './build/Release')
 
@@ -64,6 +66,9 @@ function getPackageFileName(target) {
 }
 
 function load(target) {
+  if(LOCAL_PATH) {
+    return require(LOCAL_PATH)
+  }
   return require(path.join(BUILD_PATH, getBinFileName(target)))
 }
 


### PR DESCRIPTION
When compiling an app using pkg, the .node files must be placed outside of the snapshot filesystem to properly work. This update allows specifying the location through an environment variable so that the proper .node file can be loaded.

See https://github.com/zeit/pkg#native-addons