### PR TITLE
Resolve issue with binary naming related to ABI

### DIFF
--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -52,7 +52,22 @@ function _getFileName(target) {
     throw new Error('Missing information for naming compiled binary.')
   }
 
-  return [pkgName, pkgVersion, target, platform, arch].join('-')
+  /**
+   * Electron forks Node and has its own custom ABI versions. Because of this, the ABI version
+   * included in the binary filename causes issues related to mismatched Node versions.
+   * A quick + temporary fix for this is to strip out the ABI name for suspected Electron builds.
+   * Tools such as `electron-builder` and `electron-rebuild` will include environment variables to work   * with node-gyp. We can look at those env vars to see if they have been patched to contain the word    * 'electron'.
+   * https://github.com/newrelic/node-native-metrics/pull/75
+   * It's worth pointing out that this is a patch and not a solution as this will have other (minor) repercussions
+   */
+  if (
+    (process.env.npm_config_runtime || '').includes('electron') ||
+    (process.env.npm_config_disturl || '').includes('electron')
+  ) {
+    return [pkgName, pkgVersion, target, platform, arch].join('-')
+  }
+
+  return [pkgName, pkgVersion, target, abi, platform, arch].join('-')
 }
 
 function getBinFileName(target) {

--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -56,7 +56,8 @@ function _getFileName(target) {
    * Electron forks Node and has its own custom ABI versions. Because of this, the ABI version
    * included in the binary filename causes issues related to mismatched Node versions.
    * A quick + temporary fix for this is to strip out the ABI name for suspected Electron builds.
-   * Tools such as `electron-builder` and `electron-rebuild` will include environment variables to work   * with node-gyp. We can look at those env vars to see if they have been patched to contain the word    * 'electron'.
+   * Tools such as `electron-builder` and `electron-rebuild` will include environment variables to work
+   * with node-gyp. We can look at those env vars to see if they have been patched to contain the word 'electron'.
    * https://github.com/newrelic/node-native-metrics/pull/75
    * It's worth pointing out that this is a patch and not a solution as this will have other (minor) repercussions
    */

--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -53,13 +53,16 @@ function _getFileName(target) {
   }
 
   /**
-   * Electron forks Node and has its own custom ABI versions. Because of this, the ABI version
-   * included in the binary filename causes issues related to mismatched Node versions.
-   * A quick + temporary fix for this is to strip out the ABI name for suspected Electron builds.
-   * Tools such as `electron-builder` and `electron-rebuild` will include environment variables to work
-   * with node-gyp. We can look at those env vars to see if they have been patched to contain the word 'electron'.
+   * Electron forks Node and has its own custom ABI versions. Because of this,
+   * the ABI version.included in the binary filename causes issues related to 
+   * mismatched Node versions. A quick + temporary fix for this is to strip out 
+   * the ABI name for suspected Electron builds. Tools such as `electron-builder`
+   * and `electron-rebuild` will include environment variables to work with
+   * node-gyp. We can look at those env vars to see if they have been patched
+   * to contain the word 'electron'.
    * https://github.com/newrelic/node-native-metrics/pull/75
-   * It's worth pointing out that this is a patch and not a solution as this will have other (minor) repercussions
+   * It's worth pointing out that this is a patch and not a solution as this will
+   * have other (minor) repercussions
    */
   if (
     (process.env.npm_config_runtime || '').includes('electron') ||

--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -52,7 +52,7 @@ function _getFileName(target) {
     throw new Error('Missing information for naming compiled binary.')
   }
 
-  return [pkgName, pkgVersion, target, abi, platform, arch].join('-')
+  return [pkgName, pkgVersion, target, platform, arch].join('-')
 }
 
 function getBinFileName(target) {

--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -60,7 +60,7 @@ function _getFileName(target) {
    * and `electron-rebuild` will include environment variables to work with
    * node-gyp. We can look at those env vars to see if they have been patched
    * to contain the word 'electron'.
-   * https://github.com/newrelic/node-native-metrics/pull/75
+   * For more context: https://github.com/newrelic/node-native-metrics/pull/75
    * It's worth pointing out that this is a patch and not a solution as this will
    * have other (minor) repercussions
    */


### PR DESCRIPTION
Based on [this thread](https://discuss.newrelic.com/t/newrelic-native-metrics-not-working-with-electron-8-x/101400) there is an issue for Electron users attempting to rebuild the native dependency and failing to load it correctly due to the ABI being included in the binary name.

This resolves the issue as the binary is _built_ with the correct ABI when using tools such as `electron-rebuild` or `electron-builder install-app-deps` but the naming convention would make it fail to load the binary in the newrelic agent in the Electron context.

Some things to note re: testing

- Tests were failing on a clean master branch checkout
- Different tests fail on every run of `npm test`
- The same thing happens when adding this patch. 🤷 