### PR TITLE
 workaround for json files without a .json file extension not working

### DIFF
--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -44,7 +44,7 @@ function _getFileName(target) {
   var abi = process.versions.modules
   var arch = process.arch
   var platform = process.platform
-  var pkg = require('../package')
+  var pkg = require('../package.json')
   var pkgName = pkg.name.replace(/[^\w]/g, '_')
   var pkgVersion = pkg.version.toString().replace(/[^\w]/g, '_')
 


### PR DESCRIPTION
 workaround for JSON files without a .json file extension not working

<img width="1176" alt="Screenshot 2020-05-12 at 11 11 04 AM" src="https://user-images.githubusercontent.com/11535686/81642576-5484dd00-9441-11ea-971c-ed9dde657477.png">

Here is the open issue: https://github.com/microsoft/TypeScript/issues/24357