### PR TITLE
Release v6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### v6.0.1 (2021-06-15):
+
+* Created a standalone upload script to avoid issues where aws-sdk does not exist.
+* Bumped tap to ^15.0.9.
+* Replaced deprecated tap methods with preferred ones.
+* Updated CONTRIBUTING.md to reference the New Relic org wide Code of Conduct.
+* Added lib/upload.js to the .npmignore as it is not needed for the module to function.
+
 ### v6.0.0 (2020-11-03):
 
 * Removed Node v8.x from ci.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Replaced deprecated tap methods with preferred ones.
 * Updated CONTRIBUTING.md to reference the New Relic org wide Code of Conduct.
 * Added lib/upload.js to the .npmignore as it is not needed for the module to function.
+* Bumped nan to ^2.14.2.
 
 ### v6.0.0 (2020-11-03):
 


### PR DESCRIPTION
## Proposed Release Notes
* Created a standalone upload script to avoid issues where aws-sdk does not exist.
* Bumped tap to ^15.0.9.
* Replaced deprecated tap methods with preferred ones.
* Updated CONTRIBUTING.md to reference the New Relic org wide Code of Conduct.
* Added lib/upload.js to the .npmignore as it is not needed for the module to function.
* Bumped nan to ^2.14.2.
## Links
https://github.com/newrelic/node-native-metrics/pull/132
https://github.com/newrelic/node-native-metrics/pull/131
https://github.com/newrelic/node-native-metrics/pull/130
https://github.com/newrelic/node-native-metrics/pull/128
https://github.com/newrelic/node-native-metrics/pull/127
https://github.com/newrelic/node-native-metrics/pull/122
## Details
