### PR TITLE
Changes hasCalledBack from a constant to a variable

### DIFF
--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -206,10 +206,10 @@ function moveBuild(target, cb) {
 
 function download(target, cb) {
   /* eslint-disable no-console */
-  const hasCalledBack = false
   const fileName = getPackageFileName(target)
   const url = DOWNLOAD_HOST + REMOTE_PATH + fileName
   let client = null
+  let hasCalledBack = false
 
   if (DOWNLOAD_HOST.startsWith('https:')) {
     client = https


### PR DESCRIPTION
## Summary

Our pipeline was running and failing to build, and it was failing because `hasCalledBack` was getting reassigned but was defined as a constant.

![pipe_error](https://user-images.githubusercontent.com/75139737/122262839-aa208a00-ce8a-11eb-9afa-3290c049fdbc.png)

## Proposed Release Notes

Changes hasCalledBack from a constant to a variable to avoid failure when it gets reassigned.

## Details

I see you have some linting running. Not sure why it wouldn't have caught this kind of error.
