### PR TITLE
Excludes native metric install setup time from test timeout for soak tests

### DIFF
--- a/tests/integration/server.tap.js
+++ b/tests/integration/server.tap.js
@@ -11,11 +11,21 @@ const segs = require('segfault-handler')
 const { execSync } = require('child_process')
 
 const RUN_TIME = 5 * 60 * 1000 // 5 minutes
+const TEST_TIMEOUT = RUN_TIME + 10000
 
 segs.registerHandler('crash.log')
 
-tap.test('server soak test', {timeout: RUN_TIME + 10000}, function(t) {
-  execSync(`node ./lib/pre-build install native_metrics`)
+tap.test('server soak test', { timeout: TEST_TIMEOUT }, function(t) {
+  t.comment('Installing native metrics')
+  const { output, elapsed } = installNativeMetrics()
+  t.comment(output)
+
+  // We increase the timeout by the install time to avoid counting against the
+  // execution time threshold while still setting up in the test execution.
+  const newTimeout = TEST_TIMEOUT + elapsed
+  t.comment('Setting new timeout: ', newTimeout)
+  t.setTimeout(newTimeout)
+
   const natives = require('../../')()
   t.comment('Running test server for ' + RUN_TIME + 'ms')
   const server = http.createServer(function(req, res) {
@@ -66,3 +76,15 @@ tap.test('server soak test', {timeout: RUN_TIME + 10000}, function(t) {
     })
   }
 })
+
+function installNativeMetrics() {
+  const start = new Date()
+  const output =
+    execSync(`node ./lib/pre-build install native_metrics`, {encoding: 'utf-8'})
+
+  const elapsed = new Date() - start
+  return {
+    elapsed,
+    output
+  }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Fixed intermittent timeout issue with the server smoke integration test.

  Excluded native metric install setup time from server soak test timeout.

## Links

## Details

When the native metric install was added to the test directly, instead of relying on it already existing via another test, this added execution time to the test which can bump it over the existing test execution threshold. That change was introduced with this PR: https://github.com/newrelic/node-native-metrics/pull/147. While the setup time varies greatly on my machine, it fails consistently. On the server, it passed initially but was failing today likely due to slowness on the GitHub actions side.

I liked that the setup was happening as a part of the test, so I bumped the timeout. Instead of arbitrarily trying to pick an upper bound, I dynamically update the timeout. It is a bit awkward but it seems that the install time could vary by newer/older environment more than we'd want to account for. This way we set a test run threshold that sets a reasonable bound for what is executing in the test itself, ignoring the setup time.

Given it is slightly funky (I've never done this in a test before) I'm open to a different approach if others do not like it.