### PR TITLE
Removes up-front test timeout for soak test.

### DIFF
--- a/tests/integration/server.tap.js
+++ b/tests/integration/server.tap.js
@@ -15,10 +15,11 @@ const TEST_TIMEOUT = RUN_TIME + 10000
 
 segs.registerHandler('crash.log')
 
-tap.test('server soak test', { timeout: TEST_TIMEOUT }, function(t) {
+tap.test('server soak test', function(t) {
   t.comment('Installing native metrics')
   const { output, elapsed } = installNativeMetrics()
-  t.comment(output)
+  t.comment('Finished installing')
+  t.comment('Output: ', output)
 
   // We increase the timeout by the install time to avoid counting against the
   // execution time threshold while still setting up in the test execution.


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details

Looks like for these runs the API set value was not overwriting the value set with the test declaration options. This PR removes the options from the sub-test and just relies on the API set value.

Over multiple CI runs and close examination this *seems* to be working consistently. This run went pretty long `ok 1 - server soak test # time=313968.272ms` and would have failed prior. 🤞 
