### PR TITLE
delay checking node-gyp version during build of module

### DIFF
--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -34,7 +34,6 @@ const {
 
 const CPU_COUNT = os.cpus().length
 const IS_WIN = process.platform === 'win32'
-const HAS_OLD_NODE_GYP_ARGS_FOR_WINDOWS = semver.lt(gypVersion() || '0.0.0', '3.7.0')
 const DOWNLOAD_HOST =
   process.env.NR_NATIVE_METRICS_DOWNLOAD_HOST || 'https://download.newrelic.com/'
 
@@ -182,6 +181,8 @@ function execGyp(args, cb) {
 }
 
 function build(target, rebuild, cb) {
+  const HAS_OLD_NODE_GYP_ARGS_FOR_WINDOWS = semver.lt(gypVersion() || '0.0.0', '3.7.0')
+
   if (IS_WIN && HAS_OLD_NODE_GYP_ARGS_FOR_WINDOWS) {
     target = '/t:' + target
   }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Updated code to only check `node-gyp` version when the module needs to be built to avoid hanging node and subsequently causing OOM errors.

## Links
Closes #155 

## Details
Per the ticket this is closing there is more info in https://github.com/newrelic/node-newrelic/issues/831 regarding how this surfaces to a user