### PR TITLE
Release v7.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+### v7.0.2 (2021-08-26):
+* Updated code to only check `node-gyp` version when the module needs to be built to avoid hanging node and subsequently causing OOM errors.
+* Added a pre-commit hook to check if package.json changes and run `oss third-party manifest` and `oss third-party notices`. This will ensure the `third_party_manifest.json` and `THIRD_PARTY_NOTICES.md` are up to date.
+* Fixed intermittent timeout issue with the server smoke integration test.
+
+  Excluded native metric install setup time from server soak test timeout.
+* Added `@newrelic/eslint-config` to rely on a centralized eslint ruleset.
+* Added `husky` + `lint-staged` to run linting on all staged js files.
+* Added integration tests for pre-build and upload tasks.
+* Upgraded setup-node CI job to v2 and changed the linting node version to `lts/*` for future proofing.
+
 ### v7.0.1 (2021-07-20):
 
 * Added support for Node 16.


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
* Updated code to only check `node-gyp` version when the module needs to be built to avoid hanging node and subsequently causing OOM errors.
* Added a pre-commit hook to check if package.json changes and run `oss third-party manifest` and `oss third-party notices`. This will ensure the `third_party_manifest.json` and `THIRD_PARTY_NOTICES.md` are up to date.
* Fixed intermittent timeout issue with the server smoke integration test.

  Excluded native metric install setup time from server soak test timeout.
* Added `@newrelic/eslint-config` to rely on a centralized eslint ruleset.
* Added `husky` + `lint-staged` to run linting on all staged js files.
* Added integration tests for pre-build and upload tasks.
* Upgraded setup-node CI job to v2 and changed the linting node version to `lts/*` for future proofing.

## Links
https://github.com/newrelic/node-native-metrics/pull/156
https://github.com/newrelic/node-native-metrics/pull/153
https://github.com/newrelic/node-native-metrics/pull/151
https://github.com/newrelic/node-native-metrics/pull/150
https://github.com/newrelic/node-native-metrics/pull/149
https://github.com/newrelic/node-native-metrics/pull/148
https://github.com/newrelic/node-native-metrics/pull/145
