### PR TITLE
skips the download test for now until we can fix holistically

### DIFF
--- a/tests/integration/pre-build.tap.js
+++ b/tests/integration/pre-build.tap.js
@@ -47,7 +47,9 @@ tap.test('pre-build commands', function (t) {
     t.end()
   })
 
-  t.test('download', { skip: NO_PREBUILTS.includes(platform) }, function (t) {
+  // t.test('download', { skip: NO_PREBUILTS.includes(platform) }, function (t) {
+  // this will fail when we release because the new pre-built does not exist
+  t.test('download', { skip: true }, function (t) {
     execSync('node ./lib/pre-build --no-build install native_metrics')
     const binary = findBinary()
     t.match(


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Details
Removes the download integration test because we're in a chicken and egg scenario where it's trying to download a new version but to upload a new version it runs this test.
