### PR TITLE
adds a new trigger to automatically invoke this workflow when `Create Release` finishes

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -2,12 +2,15 @@ name: native-metrics Binary Upload
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*' # Push events to matching v*, e.g. v1.0, v20.15.10
+  workflow_run:
+    workflows: ["Create Release"]
+    types:
+      - completed
 
 jobs:
   build-test-upload:
+     # Check if this was a manual invocation(workflow_dispatch) or triggered(workflow_run) and successful
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run && github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Changed trigger on binary upload to wait for release of module instead of waiting for a tag that starts with `v` to be created

## Links
Closes #172

## Details
When we added release automation the binary upload was never getting invoked because the tag was getting pushed by the github actions workflow.  This does not invoke other workflows unless you use a personal access token.  Instead of updating the release workflow to use a PAT, I changed the trigger to wait for `Create Release` to be done before doing the binary upload.
