### PR TITLE
Modifies CI workflow to use windows-2019.

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -52,7 +52,7 @@ jobs:
       run: npm run integration
 
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
 
     strategy:
       matrix:


### PR DESCRIPTION
windows-latest is now Server 2022 which is currently failing to compile due to missing VS tooling warnings.

<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Updated CI workflow to use `windows-2019` image instead of `windows-latest`.

## Links

## Details

The `windows-2022` image is now used for `windows-latest` and is causing our builds to fail. Setting to 2019 for now so we can get a release out and then I'll dig in deeper.