### PR TITLE
Adds coverage back for windows-latest (2022) for just Node 16.

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Run Integration
       run: npm run integration
 
-  windows:
+  windows-2019:
     runs-on: windows-2019
 
     strategy:
@@ -64,6 +64,40 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
+    - name: Install Dependencies
+      run: npm ci
+    - name: Rebuild
+      run: npm run rebuild
+    - name: Run Unit
+      run: npm run unit
+    - name: Run Integration
+      run: npm run integration
+
+  windows-latest:
+    runs-on: windows-latest
+
+    # Node 16+ should eventually bundle node-gyp>=8.4.0 to be compatible with Server 2022.
+    # Once compatible, can remove node-gyp upgrade.
+    strategy:
+      matrix:
+        node-version: [16.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Get Node Version
+      id: node_version
+      run: echo "::set-output name=version::$(node --version | sed 's/^.//')"
+
+    # https://github.com/nodejs/node-gyp/blob/master/docs/Updating-npm-bundled-node-gyp.md#windows
+    - name: Upgrade node-gyp in npm
+      run: |
+        cd "C:\hostedtoolcache\windows\node\${{ steps.node_version.outputs.version }}\x64"
+        cd node_modules\npm\node_modules\@npmcli\run-script
+        npm install node-gyp@>=8.4.0
     - name: Install Dependencies
       run: npm ci
     - name: Rebuild


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Added `windows-latest` run for Node 16 only back to CI.

## Links

* Fixes: https://github.com/newrelic/node-native-metrics/issues/182

## Details

We should eventually be able to remove the `node-gyp` upgrade once a new enough version of npm/node-gyp are bundled in later versions of Node 16.

I'm just running on the latest for now to reduce friction but have an understanding of 2022 coverage and resolving node-gyp issue for Windows users. 

I'm guessing by the time we add Node 18 support, Node 16 will naturally support the newer `node-gyp`. At that time, we can prob leave only Node 14 on `windows-2019` and have 16 and 18 on `windows-latest`.

If we agree on this approach, at least for the short term, we can update the branch protection rules for the new names.