### PR TITLE
Bumps minimum nan version to ^2.16.0.

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -59,16 +59,12 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ### nan
 
-This product includes source derived from [nan](https://github.com/nodejs/nan) ([v2.15.0](https://github.com/nodejs/nan/tree/v2.15.0)), distributed under the [MIT License](https://github.com/nodejs/nan/blob/v2.15.0/LICENSE.md):
+This product includes source derived from [nan](https://github.com/nodejs/nan) ([v2.16.0](https://github.com/nodejs/nan/tree/v2.16.0)), distributed under the [MIT License](https://github.com/nodejs/nan/blob/v2.16.0/LICENSE.md):
 
 ```
 The MIT License (MIT)
-=====================
 
-Copyright (c) 2018 NAN contributors
------------------------------------
-
-*NAN contributors listed at <https://github.com/nodejs/nan#contributors>*
+Copyright (c) 2018 [NAN contributors](<https://github.com/nodejs/nan#wg-members--collaborators>)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "https-proxy-agent": "^5.0.0",
-        "nan": "^2.15.0",
+        "nan": "^2.16.0",
         "semver": "^5.5.1"
       },
       "devDependencies": {
@@ -34,7 +34,7 @@
         "tap": "^16.0.1"
       },
       "engines": {
-        "node": ">=12",
+        "node": ">=14",
         "npm": ">=6"
       }
     },
@@ -5587,9 +5587,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -13966,9 +13966,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
   },
   "dependencies": {
     "https-proxy-agent": "^5.0.0",
-    "nan": "^2.15.0",
+    "nan": "^2.16.0",
     "semver": "^5.5.1"
   },
   "files": [

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Mon Jul 25 2022 15:52:07 GMT-0700 (Pacific Daylight Time)",
+  "lastUpdated": "Wed Jul 27 2022 09:48:33 GMT-0700 (Pacific Daylight Time)",
   "projectName": "Native Metrics for New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-native-metrics",
   "includeOptDeps": false,
@@ -19,15 +19,15 @@
       "email": "nathan@tootallnate.net",
       "url": "http://n8.io/"
     },
-    "nan@2.15.0": {
+    "nan@2.16.0": {
       "name": "nan",
-      "version": "2.15.0",
-      "range": "^2.15.0",
+      "version": "2.16.0",
+      "range": "^2.16.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/nodejs/nan",
-      "versionedRepoUrl": "https://github.com/nodejs/nan/tree/v2.15.0",
+      "versionedRepoUrl": "https://github.com/nodejs/nan/tree/v2.16.0",
       "licenseFile": "node_modules/nan/LICENSE.md",
-      "licenseUrl": "https://github.com/nodejs/nan/blob/v2.15.0/LICENSE.md",
+      "licenseUrl": "https://github.com/nodejs/nan/blob/v2.16.0/LICENSE.md",
       "licenseTextSource": "file"
     },
     "semver@5.7.1": {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Bumped minimum `nan` version to ^2.16.0.

## Links

* https://github.com/nodejs/nan/pull/937
* https://github.com/nodejs/nan/blob/main/CHANGELOG.md#2160-may-25-2022

## Details

NAN did have a small PR/release for Node 18 support. Making that our minimum: https://github.com/nodejs/nan/pull/937. 
