### PR TITLE
updated GC mapping to account for new enum types in node 18(v8 10)

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -102,7 +102,7 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ### @newrelic/eslint-config
 
-This product includes source derived from [@newrelic/eslint-config](https://github.com/newrelic/eslint-config-newrelic) ([v0.0.2](https://github.com/newrelic/eslint-config-newrelic/tree/v0.0.2)), distributed under the [Apache-2.0 License](https://github.com/newrelic/eslint-config-newrelic/blob/v0.0.2/LICENSE):
+This product includes source derived from [@newrelic/eslint-config](https://github.com/newrelic/eslint-config-newrelic) ([v0.0.4](https://github.com/newrelic/eslint-config-newrelic/tree/v0.0.4)), distributed under the [Apache-2.0 License](https://github.com/newrelic/eslint-config-newrelic/blob/v0.0.4/LICENSE):
 
 ```
                                  Apache License

--- a/lib/pre-build.js
+++ b/lib/pre-build.js
@@ -237,8 +237,8 @@ function download(target, cb) {
       return cb(new Error('Failed to download ' + url + ': code ' + res.statusCode))
     }
 
-    var unzip = zlib.createGunzip()
-    var buffers = []
+    const unzip = zlib.createGunzip()
+    const buffers = []
     let size = 0
     res.pipe(unzip).on('data', function onResData(data) {
       buffers.push(data)

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -23,7 +23,7 @@ const path = require('path')
 // XXX AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY must be set in the environment.
 const AWS = require('aws-sdk')
 const s3 = new AWS.S3()
-var S3_BUCKET = 'nr-downloads-main'
+const S3_BUCKET = 'nr-downloads-main'
 const CMD = 'upload'
 
 if (require.main === module) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "semver": "^5.5.1"
       },
       "devDependencies": {
-        "@newrelic/eslint-config": "^0.0.2",
+        "@newrelic/eslint-config": "^0.0.4",
         "@newrelic/newrelic-oss-cli": "^0.1.2",
         "@newrelic/proxy": "^2.0.0",
         "async": "^3.2.2",
@@ -564,9 +564,9 @@
       }
     },
     "node_modules/@newrelic/eslint-config": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@newrelic/eslint-config/-/eslint-config-0.0.2.tgz",
-      "integrity": "sha512-fMn9e4hShInAuZxYg5dV/qmJ48Qj6JE8eQqE6XyPiDsTriEt6A5H88PFQ50V/xmWGrSxnvmmCnXzdWgxUDaqbg==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@newrelic/eslint-config/-/eslint-config-0.0.4.tgz",
+      "integrity": "sha512-ER8LjoFbbIciPiVfHJB36nhWbo/MbKfNe8IiG+p3AHIUmm/pGqz+wF38kqsuhKA1gsr6wUNIHFQiS/4FMWF3Kg==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -10032,9 +10032,9 @@
       "dev": true
     },
     "@newrelic/eslint-config": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@newrelic/eslint-config/-/eslint-config-0.0.2.tgz",
-      "integrity": "sha512-fMn9e4hShInAuZxYg5dV/qmJ48Qj6JE8eQqE6XyPiDsTriEt6A5H88PFQ50V/xmWGrSxnvmmCnXzdWgxUDaqbg==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@newrelic/eslint-config/-/eslint-config-0.0.4.tgz",
+      "integrity": "sha512-ER8LjoFbbIciPiVfHJB36nhWbo/MbKfNe8IiG+p3AHIUmm/pGqz+wF38kqsuhKA1gsr6wUNIHFQiS/4FMWF3Kg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "npm": ">=6"
   },
   "devDependencies": {
-    "@newrelic/eslint-config": "^0.0.2",
+    "@newrelic/eslint-config": "^0.0.4",
     "@newrelic/newrelic-oss-cli": "^0.1.2",
     "@newrelic/proxy": "^2.0.0",
     "async": "^3.2.2",

--- a/tests/integration/loop-performance.tap.js
+++ b/tests/integration/loop-performance.tap.js
@@ -5,14 +5,14 @@
 
 'use strict'
 
-var tap = require('tap')
+const tap = require('tap')
 
-var TEST_DURATION = 30 * 1000
+const TEST_DURATION = 30 * 1000
 
 tap.test('loop performance test', { timeout: 2 * TEST_DURATION + 1000 }, function (t) {
-  var timeout = null
-  var callCount = 0
-  var natives = null
+  let timeout = null
+  let callCount = 0
+  let natives = null
 
   t.teardown(function () {
     if (natives) {
@@ -23,19 +23,19 @@ tap.test('loop performance test', { timeout: 2 * TEST_DURATION + 1000 }, functio
   t.comment('measuring without loop counter')
   setTimeoutCount()
   setTimeout(function () {
-    var noMetricsCount = callCount
+    const noMetricsCount = callCount
     callCount = 0
     clearTimeout(timeout)
 
     natives = require('../../')()
-    var readInterval = setInterval(function () {
+    const readInterval = setInterval(function () {
       natives.getLoopMetrics() // To reset the metrics
     }, 1000)
 
     t.comment('measuring with loop counter')
     setTimeoutCount()
     setTimeout(function () {
-      var withMetricsCount = callCount
+      const withMetricsCount = callCount
       callCount = 0
       clearTimeout(timeout)
       clearInterval(readInterval)

--- a/tests/unit/gc-metrics.tap.js
+++ b/tests/unit/gc-metrics.tap.js
@@ -5,23 +5,23 @@
 
 'use strict'
 
-var tap = require('tap')
+const tap = require('tap')
 
 tap.test('GC Metrics', function (t) {
   t.plan(17)
-  var metricEmitter = require('../../')()
+  const metricEmitter = require('../../')()
 
   global.gc()
 
-  var gcs = metricEmitter.getGCMetrics()
-  var keys = Object.keys(gcs)
+  const gcs = metricEmitter.getGCMetrics()
+  const keys = Object.keys(gcs)
   if (!t.ok(keys.length > 0, 'should notice at least one GC')) {
     return t.end()
   }
   t.type(keys[0], 'string', 'should have strings as keys')
 
   t.comment('GC stats objects')
-  var stats = gcs[keys[0]]
+  const stats = gcs[keys[0]]
   t.type(stats, 'object', 'should have stats objects')
   t.type(stats.typeId, 'number', 'should have the type ID')
   t.type(stats.type, 'string', 'should have the type name')
@@ -30,7 +30,7 @@ tap.test('GC Metrics', function (t) {
   }
 
   t.comment('GC stats metrics')
-  var metrics = stats.metrics
+  const metrics = stats.metrics
   t.type(metrics.total, 'number', 'should have total field')
   t.type(metrics.min, 'number', 'should have min field')
   t.type(metrics.max, 'number', 'should have max field')

--- a/tests/unit/licenses.tap.js
+++ b/tests/unit/licenses.tap.js
@@ -5,21 +5,21 @@
 
 'use strict'
 
-var a = require('async')
-var fs = require('fs')
-var path = require('path')
-var pkg = require('../../package')
-var tap = require('tap')
+const a = require('async')
+const fs = require('fs')
+const path = require('path')
+const pkg = require('../../package')
+const tap = require('tap')
 
-var MODULE_DIR = path.resolve(__dirname, '../../node_modules')
-var LICENSES = {
+const MODULE_DIR = path.resolve(__dirname, '../../node_modules')
+const LICENSES = {
   'nan': 'MIT',
   'https-proxy-agent': 'MIT',
   'semver': 'ISC'
 }
 
 tap.test('Dependency licenses', function (t) {
-  var deps = Object.keys(pkg.dependencies || {})
+  const deps = Object.keys(pkg.dependencies || {})
   deps.push.apply(deps, Object.keys(pkg.optionalDependencies || {}))
   a.map(
     deps,
@@ -35,8 +35,8 @@ tap.test('Dependency licenses', function (t) {
           },
           function parsePkg(depPackage, parsePkgCb) {
             try {
-              var parsedPackage = JSON.parse(depPackage)
-              var license = parsedPackage.license || parsedPackage.licenses
+              const parsedPackage = JSON.parse(depPackage)
+              const license = parsedPackage.license || parsedPackage.licenses
               process.nextTick(function () {
                 parsePkgCb(null, [dep, license])
               })
@@ -50,7 +50,7 @@ tap.test('Dependency licenses', function (t) {
     },
     function (err, depLicensesArray) {
       if (t.error(err, 'should not fail to retrieve licenses')) {
-        var depLicenses = depLicensesArray.reduce(function (obj, dep) {
+        const depLicenses = depLicensesArray.reduce(function (obj, dep) {
           obj[dep[0]] = dep[1]
           return obj
         }, {})

--- a/tests/unit/loop-metrics.tap.js
+++ b/tests/unit/loop-metrics.tap.js
@@ -5,21 +5,21 @@
 
 'use strict'
 
-var tap = require('tap')
+const tap = require('tap')
 
 tap.test('Loop Metrics', function (t) {
-  var MICRO_TO_MILLIS = 1e-3
-  var SPIN_TIME = 2000
-  var CPU_EPSILON = SPIN_TIME * 0.05 // Allowed fudge factor for CPU times in MS
-  var metricEmitter = require('../../')()
-  var testStart = Date.now()
+  const MICRO_TO_MILLIS = 1e-3
+  const SPIN_TIME = 2000
+  const CPU_EPSILON = SPIN_TIME * 0.05 // Allowed fudge factor for CPU times in MS
+  const metricEmitter = require('../../')()
+  const testStart = Date.now()
 
   t.teardown(function () {
     metricEmitter.unbind()
   })
 
   // Check the structure of the metric object.
-  var metric = metricEmitter.getLoopMetrics().usage
+  let metric = metricEmitter.getLoopMetrics().usage
   t.type(metric, Object, 'should provide a metric object')
   t.type(metric.total, 'number', 'should have a total')
   t.type(metric.min, 'number', 'should have a min')
@@ -53,17 +53,17 @@ tap.test('Loop Metrics', function (t) {
   //      the actual loop time because the process isn't doing anything.
   setTimeout(function spinner() {
     t.comment('spinning cpu...')
-    var start = Date.now()
+    const start = Date.now()
     while (Date.now() - start < SPIN_TIME) {} // Spin the CPU for 2 seconds.
 
     // Finally, wait another tick and then check the loop stats.
     setTimeout(function () {
       metric = metricEmitter.getLoopMetrics()
-      var testDuration = Date.now() - testStart + CPU_EPSILON
-      var durationSquare = testDuration * testDuration
-      var usage = metric.usage
+      const testDuration = Date.now() - testStart + CPU_EPSILON
+      const durationSquare = testDuration * testDuration
+      const usage = metric.usage
 
-      var meanTime = usage.total / usage.count
+      const meanTime = usage.total / usage.count
       t.ok(
         usage.total * MICRO_TO_MILLIS > SPIN_TIME - CPU_EPSILON,
         'should have total greater than spin time'

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "Wed Jul 27 2022 09:48:33 GMT-0700 (Pacific Daylight Time)",
+  "lastUpdated": "Fri Jul 29 2022 11:18:40 GMT-0400 (Eastern Daylight Time)",
   "projectName": "Native Metrics for New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-native-metrics",
   "includeOptDeps": false,
@@ -43,15 +43,15 @@
     }
   },
   "devDependencies": {
-    "@newrelic/eslint-config@0.0.2": {
+    "@newrelic/eslint-config@0.0.4": {
       "name": "@newrelic/eslint-config",
-      "version": "0.0.2",
-      "range": "^0.0.2",
+      "version": "0.0.4",
+      "range": "^0.0.4",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/newrelic/eslint-config-newrelic",
-      "versionedRepoUrl": "https://github.com/newrelic/eslint-config-newrelic/tree/v0.0.2",
+      "versionedRepoUrl": "https://github.com/newrelic/eslint-config-newrelic/tree/v0.0.4",
       "licenseFile": "node_modules/@newrelic/eslint-config/LICENSE",
-      "licenseUrl": "https://github.com/newrelic/eslint-config-newrelic/blob/v0.0.2/LICENSE",
+      "licenseUrl": "https://github.com/newrelic/eslint-config-newrelic/blob/v0.0.4/LICENSE",
       "licenseTextSource": "file",
       "publisher": "New Relic Node.js agent team",
       "email": "nodejs@newrelic.com"


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes
 * Fixed GC binder to properly record Garbage Collection metrics in Node 18.

## Links
Closes https://issues.newrelic.com/browse/NR-38091

## Details
After much digging I realized the GCType enum changed in [v8 10](https://v8docs.nodesource.com/node-18.2/db/d88/v8-callbacks_8h_source.html).  After figuring out the type id mapping I was able to update and see the GC stats again in NR 1.


<img width="1370" alt="screenshot 2022-07-29 at 11 21 19 AM" src="https://user-images.githubusercontent.com/1874937/181791776-ffd8baff-1ab7-4304-b27b-5cc3e8bec6a4.png">

