### PR TITLE
chore: Skipped macOS integration tests in CI

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -110,15 +110,17 @@ jobs:
           directory: ./coverage/unit/
           files: lcov.info
           flags: unit-tests-${{ matrix.node }}-${{ matrix.os }}-${{ matrix.arch }}
-      - name: Integration Test
-        run: npm run integration
-      - name: Post Integration Test Coverage
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./coverage/integration/
-          files: lcov.info
-          flags: integration-tests-${{ matrix.node }}-${{ matrix.os }}-${{ matrix.arch }}
+      # Disabled due to the macOS environment in GHA being very inconsistent,
+      # but also consistently too slow.
+#      - name: Integration Test
+#        run: npm run integration
+#      - name: Post Integration Test Coverage
+#        uses: codecov/codecov-action@v4
+#        with:
+#          token: ${{ secrets.CODECOV_TOKEN }}
+#          directory: ./coverage/integration/
+#          files: lcov.info
+#          flags: integration-tests-${{ matrix.node }}-${{ matrix.os }}-${{ matrix.arch }}
 
   test_linux_arm:
     # Skip this group if the PR doesn't originate from the main repo.


### PR DESCRIPTION
The "integration" tests on macOS fail in CI way more often than they succeed. Since they are not providing any real utility, we disable them.