### PR TITLE
feat!: Removed support for Node.js 16

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        node: [ 16, 18, 20, 22 ]
+        node: [ 18, 20, 22 ]
         arch: [ x86, x64 ]
         exclude:
           # Ubuntu does not ship x86 builds.
@@ -85,7 +85,7 @@ jobs:
 #    strategy:
 #      matrix:
 #        os: [ macos-14 ]
-#        node: [ 16, 18, 20, 22 ]
+#        node: [ 18, 20, 22 ]
 #        arch: [ arm64 ]
 #    runs-on: ${{ matrix.os }}
 #    name: "${{ matrix.os }} / Node ${{ matrix.node }} ${{ matrix.arch }}"
@@ -129,7 +129,7 @@ jobs:
     if: ${{ vars.NR_RUNNER != '' }}
     strategy:
       matrix:
-        node: [ 16, 18, 20, 22 ]
+        node: [ 18, 20, 22 ]
     runs-on: ${{ vars.NR_RUNNER }}
     name: Linux / Node ${{ matrix.node }} arm64
     timeout-minutes: 15

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        node: [ 16, 18, 20, 22 ]
+        node: [ 18, 20, 22 ]
         arch: [ x86, x64 ]
         exclude:
           # Ubuntu does not ship x86 builds.
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         os: [ macos-14 ]
-        node: [ 16, 18, 20, 22 ]
+        node: [ 18, 20, 22 ]
         arch: [ arm64 ]
     runs-on: ${{ matrix.os }}
     name: "${{ matrix.os }} / Node ${{ matrix.node }} ${{ matrix.arch }}"
@@ -78,7 +78,7 @@ jobs:
     if: ${{ vars.NR_RUNNER != '' }}
     strategy:
       matrix:
-        node: [ 16, 18, 20, 22 ]
+        node: [ 18, 20, 22 ]
     runs-on: ${{ vars.NR_RUNNER }}
     name: Linux / Node ${{ matrix.node }} arm64
     timeout-minutes: 15

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -16,9 +16,7 @@ code, the source code can be found at [https://github.com/newrelic/node-native-m
 
 * [nan](#nan)
 * [node-gyp-build](#node-gyp-build)
-* [node-gyp](#node-gyp)
 * [prebuildify](#prebuildify)
-* [semver](#semver)
 
 **[devDependencies](#devDependencies)**
 
@@ -47,7 +45,7 @@ code, the source code can be found at [https://github.com/newrelic/node-native-m
 
 ### nan
 
-This product includes source derived from [nan](https://github.com/nodejs/nan) ([v2.19.0](https://github.com/nodejs/nan/tree/v2.19.0)), distributed under the [MIT License](https://github.com/nodejs/nan/blob/v2.19.0/LICENSE.md):
+This product includes source derived from [nan](https://github.com/nodejs/nan) ([v2.20.0](https://github.com/nodejs/nan/tree/v2.20.0)), distributed under the [MIT License](https://github.com/nodejs/nan/blob/v2.20.0/LICENSE.md):
 
 ```
 The MIT License (MIT)
@@ -91,38 +89,6 @@ THE SOFTWARE.
 
 ```
 
-### node-gyp
-
-This product includes source derived from [node-gyp](https://github.com/nodejs/node-gyp) ([v10.1.0](https://github.com/nodejs/node-gyp/tree/v10.1.0)), distributed under the [MIT License](https://github.com/nodejs/node-gyp/blob/v10.1.0/LICENSE):
-
-```
-(The MIT License)
-
-Copyright (c) 2012 Nathan Rajlich <nathan@tootallnate.net>
-
-Permission is hereby granted, free of charge, to any person
-obtaining a copy of this software and associated documentation
-files (the "Software"), to deal in the Software without
-restriction, including without limitation the rights to use,
-copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
-
-```
-
 ### prebuildify
 
 This product includes source derived from [prebuildify](https://github.com/prebuild/prebuildify) ([v6.0.1](https://github.com/prebuild/prebuildify/tree/v6.0.1)), distributed under the [MIT License](https://github.com/prebuild/prebuildify/blob/v6.0.1/LICENSE):
@@ -149,29 +115,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-
-```
-
-### semver
-
-This product includes source derived from [semver](https://github.com/npm/node-semver) ([v7.5.2](https://github.com/npm/node-semver/tree/v7.5.2)), distributed under the [ISC License](https://github.com/npm/node-semver/blob/v7.5.2/LICENSE):
-
-```
-The ISC License
-
-Copyright (c) Isaac Z. Schlueter and Contributors
-
-Permission to use, copy, modify, and/or distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
-IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ```
 
@@ -613,7 +556,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ### async
 
-This product includes source derived from [async](https://github.com/caolan/async) ([v3.2.4](https://github.com/caolan/async/tree/v3.2.4)), distributed under the [MIT License](https://github.com/caolan/async/blob/v3.2.4/LICENSE):
+This product includes source derived from [async](https://github.com/caolan/async) ([v3.2.5](https://github.com/caolan/async/tree/v3.2.5)), distributed under the [MIT License](https://github.com/caolan/async/blob/v3.2.5/LICENSE):
 
 ```
 Copyright (c) 2010-2018 Caolan McMahon
@@ -640,7 +583,7 @@ THE SOFTWARE.
 
 ### aws-sdk
 
-This product includes source derived from [aws-sdk](https://github.com/aws/aws-sdk-js) ([v2.1354.0](https://github.com/aws/aws-sdk-js/tree/v2.1354.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js/blob/v2.1354.0/LICENSE.txt):
+This product includes source derived from [aws-sdk](https://github.com/aws/aws-sdk-js) ([v2.1656.0](https://github.com/aws/aws-sdk-js/tree/v2.1656.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js/blob/v2.1656.0/LICENSE.txt):
 
 ```
 
@@ -850,7 +793,7 @@ This product includes source derived from [aws-sdk](https://github.com/aws/aws-s
 
 ### c8
 
-This product includes source derived from [c8](https://github.com/bcoe/c8) ([v8.0.0](https://github.com/bcoe/c8/tree/v8.0.0)), distributed under the [ISC License](https://github.com/bcoe/c8/blob/v8.0.0/LICENSE.txt):
+This product includes source derived from [c8](https://github.com/bcoe/c8) ([v8.0.1](https://github.com/bcoe/c8/tree/v8.0.1)), distributed under the [ISC License](https://github.com/bcoe/c8/blob/v8.0.1/LICENSE.txt):
 
 ```
 Copyright (c) 2017, Contributors
@@ -872,12 +815,12 @@ ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ### eslint-config-prettier
 
-This product includes source derived from [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) ([v8.5.0](https://github.com/prettier/eslint-config-prettier/tree/v8.5.0)), distributed under the [MIT License](https://github.com/prettier/eslint-config-prettier/blob/v8.5.0/LICENSE):
+This product includes source derived from [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) ([v8.10.0](https://github.com/prettier/eslint-config-prettier/tree/v8.10.0)), distributed under the [MIT License](https://github.com/prettier/eslint-config-prettier/blob/v8.10.0/LICENSE):
 
 ```
 The MIT License (MIT)
 
-Copyright (c) 2017, 2018, 2019, 2020, 2021, 2022 Simon Lydell and contributors
+Copyright (c) 2017, 2018, 2019, 2020, 2021, 2022, 2023 Simon Lydell and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -1064,7 +1007,7 @@ SOFTWARE.
 
 ### lockfile-lint
 
-This product includes source derived from [lockfile-lint](https://github.com/lirantal/lockfile-lint) ([v4.9.6](https://github.com/lirantal/lockfile-lint/tree/v4.9.6)), distributed under the [Apache-2.0 License](https://github.com/lirantal/lockfile-lint/blob/v4.9.6/LICENSE):
+This product includes source derived from [lockfile-lint](https://github.com/lirantal/lockfile-lint) ([v4.14.0](https://github.com/lirantal/lockfile-lint/tree/v4.14.0)), distributed under the [Apache-2.0 License](https://github.com/lirantal/lockfile-lint/blob/v4.14.0/LICENSE):
 
 ```
 
@@ -1262,7 +1205,7 @@ This product includes source derived from [lockfile-lint](https://github.com/lir
 
 ### nock
 
-This product includes source derived from [nock](https://github.com/nock/nock) ([v13.2.9](https://github.com/nock/nock/tree/v13.2.9)), distributed under the [MIT License](https://github.com/nock/nock/blob/v13.2.9/LICENSE):
+This product includes source derived from [nock](https://github.com/nock/nock) ([v13.5.4](https://github.com/nock/nock/tree/v13.5.4)), distributed under the [MIT License](https://github.com/nock/nock/blob/v13.5.4/LICENSE):
 
 ```
 MIT License
@@ -1291,7 +1234,7 @@ SOFTWARE.
 
 ### prettier
 
-This product includes source derived from [prettier](https://github.com/prettier/prettier) ([v2.8.1](https://github.com/prettier/prettier/tree/v2.8.1)), distributed under the [MIT License](https://github.com/prettier/prettier/blob/v2.8.1/LICENSE):
+This product includes source derived from [prettier](https://github.com/prettier/prettier) ([v2.8.8](https://github.com/prettier/prettier/tree/v2.8.8)), distributed under the [MIT License](https://github.com/prettier/prettier/blob/v2.8.8/LICENSE):
 
 ```
 # Prettier license
@@ -1321,7 +1264,7 @@ Repository: <https://github.com/angular/angular.git>
 
 ----------------------------------------
 
-### @babel/code-frame@v7.16.7
+### @babel/code-frame@v7.18.6
 
 License: MIT
 By: The Babel Team
@@ -1352,7 +1295,7 @@ Repository: <https://github.com/babel/babel.git>
 
 ----------------------------------------
 
-### @babel/helper-validator-identifier@v7.18.6
+### @babel/helper-validator-identifier@v7.19.1
 
 License: MIT
 By: The Babel Team
@@ -1383,7 +1326,7 @@ Repository: <https://github.com/babel/babel.git>
 
 ----------------------------------------
 
-### @babel/highlight@v7.16.10
+### @babel/highlight@v7.18.6
 
 License: MIT
 By: The Babel Team
@@ -1414,7 +1357,7 @@ Repository: <https://github.com/babel/babel.git>
 
 ----------------------------------------
 
-### @babel/parser@v7.20.1
+### @babel/parser@v7.21.3
 
 License: MIT
 By: The Babel Team
@@ -1633,14 +1576,14 @@ License: MIT
 
 ----------------------------------------
 
-### @typescript-eslint/types@v5.45.0
+### @typescript-eslint/types@v5.55.0
 
 License: MIT
 Repository: <https://github.com/typescript-eslint/typescript-eslint.git>
 
 > MIT License
 >
-> Copyright (c) 2019 TypeScript ESLint and other contributors
+> Copyright (c) 2019 typescript-eslint and other contributors
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
@@ -1662,7 +1605,7 @@ Repository: <https://github.com/typescript-eslint/typescript-eslint.git>
 
 ----------------------------------------
 
-### @typescript-eslint/typescript-estree@v5.45.0
+### @typescript-eslint/typescript-estree@v5.55.0
 
 License: BSD-2-Clause
 Repository: <https://github.com/typescript-eslint/typescript-eslint.git>
@@ -1677,11 +1620,11 @@ Repository: <https://github.com/typescript-eslint/typescript-eslint.git>
 > Redistribution and use in source and binary forms, with or without
 > modification, are permitted provided that the following conditions are met:
 >
->   * Redistributions of source code must retain the above copyright
->     notice, this list of conditions and the following disclaimer.
->   * Redistributions in binary form must reproduce the above copyright
->     notice, this list of conditions and the following disclaimer in the
->     documentation and/or other materials provided with the distribution.
+> - Redistributions of source code must retain the above copyright
+>   notice, this list of conditions and the following disclaimer.
+> - Redistributions in binary form must reproduce the above copyright
+>   notice, this list of conditions and the following disclaimer in the
+>   documentation and/or other materials provided with the distribution.
 >
 > THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 > AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -1696,14 +1639,14 @@ Repository: <https://github.com/typescript-eslint/typescript-eslint.git>
 
 ----------------------------------------
 
-### @typescript-eslint/visitor-keys@v5.45.0
+### @typescript-eslint/visitor-keys@v5.55.0
 
 License: MIT
 Repository: <https://github.com/typescript-eslint/typescript-eslint.git>
 
 > MIT License
 >
-> Copyright (c) 2019 TypeScript ESLint and other contributors
+> Copyright (c) 2019 typescript-eslint and other contributors
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal
@@ -1725,7 +1668,7 @@ Repository: <https://github.com/typescript-eslint/typescript-eslint.git>
 
 ----------------------------------------
 
-### acorn@v8.8.0
+### acorn@v8.8.1
 
 License: MIT
 Repository: <https://github.com/acornjs/acorn.git>
@@ -2539,14 +2482,15 @@ By: Jon Schlinkert
 
 ----------------------------------------
 
-### defaults@v1.0.3
+### defaults@v1.0.4
 
 License: MIT
 By: Elijah Insua
-Repository: <git://github.com/tmpvar/defaults.git>
+Repository: <git://github.com/sindresorhus/node-defaults.git>
 
 > The MIT License (MIT)
 >
+> Copyright (c) 2022 Sindre Sorhus
 > Copyright (c) 2015 Elijah Insua
 >
 > Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -2569,7 +2513,7 @@ Repository: <git://github.com/tmpvar/defaults.git>
 
 ----------------------------------------
 
-### del@v6.0.0
+### del@v6.1.1
 
 License: MIT
 By: Sindre Sorhus
@@ -2687,7 +2631,7 @@ Repository: <git://github.com/editorconfig/editorconfig-core-js.git>
 
 ----------------------------------------
 
-### editorconfig-to-prettier@v0.2.0
+### editorconfig-to-prettier@v1.0.0
 
 License: ISC
 By: Joseph Frazier
@@ -3007,7 +2951,7 @@ By: Toru Nagashima
 
 ----------------------------------------
 
-### espree@v9.4.0
+### espree@v9.4.1
 
 License: BSD-2-Clause
 By: Nicholas C. Zakas
@@ -3115,7 +3059,7 @@ Repository: <https://github.com/justmoon/node-extend.git>
 
 ----------------------------------------
 
-### fast-glob@v3.2.11
+### fast-glob@v3.2.12
 
 License: MIT
 By: Denis Malinochkin
@@ -3174,7 +3118,7 @@ Repository: <git://github.com/epoberezkin/fast-json-stable-stringify.git>
 
 ----------------------------------------
 
-### fastq@v1.13.0
+### fastq@v1.14.0
 
 License: ISC
 By: Matteo Collina
@@ -3348,7 +3292,7 @@ By: Roy Riojas
 
 ----------------------------------------
 
-### flatted@v3.2.5
+### flatted@v3.2.7
 
 License: ISC
 By: Andrea Giammarchi
@@ -3523,7 +3467,7 @@ By: Sindre Sorhus
 
 ----------------------------------------
 
-### glob@v7.2.0
+### glob@v7.2.3
 
 License: ISC
 By: Isaac Z. Schlueter
@@ -3593,14 +3537,14 @@ By: Sindre Sorhus
 
 ----------------------------------------
 
-### graceful-fs@v4.2.9
+### graceful-fs@v4.2.10
 
 License: ISC
 Repository: <https://github.com/isaacs/node-graceful-fs>
 
 > The ISC License
 >
-> Copyright (c) Isaac Z. Schlueter, Ben Noordhuis, and Contributors
+> Copyright (c) 2011-2022 Isaac Z. Schlueter, Ben Noordhuis, and Contributors
 >
 > Permission to use, copy, modify, and/or distribute this software for any
 > purpose with or without fee is hereby granted, provided that the above
@@ -3724,36 +3668,6 @@ By: Titus Wormer
 ----------------------------------------
 
 ### html-tag-names@v2.0.1
-
-License: MIT
-By: Titus Wormer
-
-> (The MIT License)
->
-> Copyright (c) 2016 Titus Wormer <tituswormer@gmail.com>
->
-> Permission is hereby granted, free of charge, to any person obtaining
-> a copy of this software and associated documentation files (the
-> 'Software'), to deal in the Software without restriction, including
-> without limitation the rights to use, copy, modify, merge, publish,
-> distribute, sublicense, and/or sell copies of the Software, and to
-> permit persons to whom the Software is furnished to do so, subject to
-> the following conditions:
->
-> The above copyright notice and this permission notice shall be
-> included in all copies or substantial portions of the Software.
->
-> THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
-> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-> IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-> CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-> TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-> SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-----------------------------------------
-
-### html-void-elements@v2.0.1
 
 License: MIT
 By: Titus Wormer
@@ -4022,6 +3936,36 @@ Repository: <git@github.com:kaelzhang/node-ignore.git>
 
 ----------------------------------------
 
+### ignore@v5.2.4
+
+License: MIT
+By: kael
+Repository: <git@github.com:kaelzhang/node-ignore.git>
+
+> Copyright (c) 2013 Kael Zhang <i@kael.me>, contributors
+> http://kael.me/
+>
+> Permission is hereby granted, free of charge, to any person obtaining
+> a copy of this software and associated documentation files (the
+> "Software"), to deal in the Software without restriction, including
+> without limitation the rights to use, copy, modify, merge, publish,
+> distribute, sublicense, and/or sell copies of the Software, and to
+> permit persons to whom the Software is furnished to do so, subject to
+> the following conditions:
+>
+> The above copyright notice and this permission notice shall be
+> included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+> NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+> LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+> OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+> WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----------------------------------------
+
 ### import-fresh@v3.3.0
 
 License: MIT
@@ -4253,7 +4197,7 @@ Repository: <git://github.com/feross/is-buffer.git>
 
 ----------------------------------------
 
-### is-core-module@v2.8.1
+### is-core-module@v2.11.0
 
 License: MIT
 By: Jordan Harband
@@ -4689,7 +4633,7 @@ By: Kat Marchán
 
 ----------------------------------------
 
-### json5@v2.2.1
+### json5@v2.2.2
 
 License: MIT
 By: Aseem Kishore
@@ -5953,7 +5897,7 @@ By: Jon Schlinkert
 
 ----------------------------------------
 
-### resolve@v1.22.0
+### resolve@v1.22.1
 
 License: MIT
 By: James Halliday
@@ -6139,6 +6083,30 @@ License: ISC
 ----------------------------------------
 
 ### semver@v7.3.7
+
+License: ISC
+By: GitHub Inc.
+Repository: <https://github.com/npm/node-semver.git>
+
+> The ISC License
+>
+> Copyright (c) Isaac Z. Schlueter and Contributors
+>
+> Permission to use, copy, modify, and/or distribute this software for any
+> purpose with or without fee is hereby granted, provided that the above
+> copyright notice and this permission notice appear in all copies.
+>
+> THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+> WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+> MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+> ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+> WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+> ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+> IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+----------------------------------------
+
+### semver@v7.3.8
 
 License: ISC
 By: GitHub Inc.
@@ -6593,7 +6561,7 @@ Repository: <https://github.com/ajafff/tsutils>
 
 ----------------------------------------
 
-### typescript@v4.9.3
+### typescript@v5.0.2
 
 License: Apache-2.0
 By: Microsoft Corp.
@@ -7310,7 +7278,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ### tap
 
-This product includes source derived from [tap](https://github.com/tapjs/node-tap) ([v16.3.7](https://github.com/tapjs/node-tap/tree/v16.3.7)), distributed under the [ISC License](https://github.com/tapjs/node-tap/blob/v16.3.7/LICENSE):
+This product includes source derived from [tap](https://github.com/tapjs/node-tap) ([v16.3.10](https://github.com/tapjs/node-tap/tree/v16.3.10)), distributed under the [ISC License](https://github.com/tapjs/node-tap/blob/v16.3.10/LICENSE):
 
 ```
 The ISC License

--- a/index.js
+++ b/index.js
@@ -8,32 +8,15 @@
 const EventEmitter = require('events').EventEmitter
 const util = require('util')
 const natives = require('node-gyp-build')(__dirname)
-const semver = require('semver')
-
 const DEFAULT_TIMEOUT = 15 * 1000 // 15 seconds
-let GC_TYPE_NAMES = null
 
-// In Node 18(v8 10) the GCType enum added `MinorMarkCompact`
-// we have to update our mapping to properly account for this
-if (semver.satisfies(process.version, '>=18')) {
-  GC_TYPE_NAMES = {
-    1: 'Scavenge',
-    2: 'MinorMarkCompact',
-    4: 'MarkSweepCompact',
-    8: 'IncrementalMarking',
-    16: 'ProcessWeakCallbacks',
-    31: 'All'
-  }
-} else {
-  GC_TYPE_NAMES = {
-    1: 'Scavenge',
-    2: 'MarkSweepCompact',
-    4: 'IncrementalMarking',
-    8: 'ProcessWeakCallbacks',
-
-    3: 'All', // Node v4 and earlier only have Scavenge and MarkSweepCompact.
-    15: 'All'
-  }
+const GC_TYPE_NAMES = {
+  1: 'Scavenge',
+  2: 'MinorMarkCompact',
+  4: 'MarkSweepCompact',
+  8: 'IncrementalMarking',
+  16: 'ProcessWeakCallbacks',
+  31: 'All'
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   ],
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=16",
+    "node": ">=18",
     "npm": ">=6"
   },
   "devDependencies": {
@@ -97,10 +97,8 @@
   },
   "dependencies": {
     "nan": "^2.19.0",
-    "node-gyp": "^10.1.0",
     "node-gyp-build": "^4.8.1",
-    "prebuildify": "^6.0.1",
-    "semver": "^7.5.2"
+    "prebuildify": "^6.0.1"
   },
   "files": [
     "index.js",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,19 +1,19 @@
 {
-  "lastUpdated": "Tue Jun 25 2024 16:07:21 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Wed Jul 24 2024 13:30:43 GMT-0400 (Eastern Daylight Time)",
   "projectName": "Native Metrics for New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-native-metrics",
   "includeOptDeps": false,
   "includeDev": true,
   "dependencies": {
-    "nan@2.19.0": {
+    "nan@2.20.0": {
       "name": "nan",
-      "version": "2.19.0",
+      "version": "2.20.0",
       "range": "^2.19.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/nodejs/nan",
-      "versionedRepoUrl": "https://github.com/nodejs/nan/tree/v2.19.0",
+      "versionedRepoUrl": "https://github.com/nodejs/nan/tree/v2.20.0",
       "licenseFile": "node_modules/nan/LICENSE.md",
-      "licenseUrl": "https://github.com/nodejs/nan/blob/v2.19.0/LICENSE.md",
+      "licenseUrl": "https://github.com/nodejs/nan/blob/v2.20.0/LICENSE.md",
       "licenseTextSource": "file"
     },
     "node-gyp-build@4.8.1": {
@@ -29,20 +29,6 @@
       "publisher": "Mathias Buus",
       "url": "@mafintosh"
     },
-    "node-gyp@10.1.0": {
-      "name": "node-gyp",
-      "version": "10.1.0",
-      "range": "^10.1.0",
-      "licenses": "MIT",
-      "repoUrl": "https://github.com/nodejs/node-gyp",
-      "versionedRepoUrl": "https://github.com/nodejs/node-gyp/tree/v10.1.0",
-      "licenseFile": "node_modules/node-gyp/LICENSE",
-      "licenseUrl": "https://github.com/nodejs/node-gyp/blob/v10.1.0/LICENSE",
-      "licenseTextSource": "file",
-      "publisher": "Nathan Rajlich",
-      "email": "nathan@tootallnate.net",
-      "url": "http://tootallnate.net"
-    },
     "prebuildify@6.0.1": {
       "name": "prebuildify",
       "version": "6.0.1",
@@ -55,18 +41,6 @@
       "licenseTextSource": "file",
       "publisher": "Mathias Buus",
       "url": "@mafintosh"
-    },
-    "semver@7.5.2": {
-      "name": "semver",
-      "version": "7.5.2",
-      "range": "^7.5.2",
-      "licenses": "ISC",
-      "repoUrl": "https://github.com/npm/node-semver",
-      "versionedRepoUrl": "https://github.com/npm/node-semver/tree/v7.5.2",
-      "licenseFile": "node_modules/semver/LICENSE",
-      "licenseUrl": "https://github.com/npm/node-semver/blob/v7.5.2/LICENSE",
-      "licenseTextSource": "file",
-      "publisher": "GitHub Inc."
     }
   },
   "devDependencies": {
@@ -109,53 +83,53 @@
       "email": "nathan@tootallnate.net",
       "url": "http://n8.io/"
     },
-    "async@3.2.4": {
+    "async@3.2.5": {
       "name": "async",
-      "version": "3.2.4",
+      "version": "3.2.5",
       "range": "^3.2.2",
       "licenses": "MIT",
       "repoUrl": "https://github.com/caolan/async",
-      "versionedRepoUrl": "https://github.com/caolan/async/tree/v3.2.4",
+      "versionedRepoUrl": "https://github.com/caolan/async/tree/v3.2.5",
       "licenseFile": "node_modules/async/LICENSE",
-      "licenseUrl": "https://github.com/caolan/async/blob/v3.2.4/LICENSE",
+      "licenseUrl": "https://github.com/caolan/async/blob/v3.2.5/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Caolan McMahon"
     },
-    "aws-sdk@2.1354.0": {
+    "aws-sdk@2.1656.0": {
       "name": "aws-sdk",
-      "version": "2.1354.0",
+      "version": "2.1656.0",
       "range": "^2.266.1",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/aws/aws-sdk-js",
-      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js/tree/v2.1354.0",
+      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js/tree/v2.1656.0",
       "licenseFile": "node_modules/aws-sdk/LICENSE.txt",
-      "licenseUrl": "https://github.com/aws/aws-sdk-js/blob/v2.1354.0/LICENSE.txt",
+      "licenseUrl": "https://github.com/aws/aws-sdk-js/blob/v2.1656.0/LICENSE.txt",
       "licenseTextSource": "file",
       "publisher": "Amazon Web Services",
       "url": "https://aws.amazon.com/"
     },
-    "c8@8.0.0": {
+    "c8@8.0.1": {
       "name": "c8",
-      "version": "8.0.0",
+      "version": "8.0.1",
       "range": "^8.0.0",
       "licenses": "ISC",
       "repoUrl": "https://github.com/bcoe/c8",
-      "versionedRepoUrl": "https://github.com/bcoe/c8/tree/v8.0.0",
+      "versionedRepoUrl": "https://github.com/bcoe/c8/tree/v8.0.1",
       "licenseFile": "node_modules/c8/LICENSE.txt",
-      "licenseUrl": "https://github.com/bcoe/c8/blob/v8.0.0/LICENSE.txt",
+      "licenseUrl": "https://github.com/bcoe/c8/blob/v8.0.1/LICENSE.txt",
       "licenseTextSource": "file",
       "publisher": "Ben Coe",
       "email": "ben@npmjs.com"
     },
-    "eslint-config-prettier@8.5.0": {
+    "eslint-config-prettier@8.10.0": {
       "name": "eslint-config-prettier",
-      "version": "8.5.0",
+      "version": "8.10.0",
       "range": "^8.3.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/prettier/eslint-config-prettier",
-      "versionedRepoUrl": "https://github.com/prettier/eslint-config-prettier/tree/v8.5.0",
+      "versionedRepoUrl": "https://github.com/prettier/eslint-config-prettier/tree/v8.10.0",
       "licenseFile": "node_modules/eslint-config-prettier/LICENSE",
-      "licenseUrl": "https://github.com/prettier/eslint-config-prettier/blob/v8.5.0/LICENSE",
+      "licenseUrl": "https://github.com/prettier/eslint-config-prettier/blob/v8.10.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Simon Lydell"
     },
@@ -234,42 +208,42 @@
       "publisher": "Andrey Okonetchnikov",
       "email": "andrey@okonet.ru"
     },
-    "lockfile-lint@4.9.6": {
+    "lockfile-lint@4.14.0": {
       "name": "lockfile-lint",
-      "version": "4.9.6",
+      "version": "4.14.0",
       "range": "^4.9.6",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/lirantal/lockfile-lint",
-      "versionedRepoUrl": "https://github.com/lirantal/lockfile-lint/tree/v4.9.6",
+      "versionedRepoUrl": "https://github.com/lirantal/lockfile-lint/tree/v4.14.0",
       "licenseFile": "node_modules/lockfile-lint/LICENSE",
-      "licenseUrl": "https://github.com/lirantal/lockfile-lint/blob/v4.9.6/LICENSE",
+      "licenseUrl": "https://github.com/lirantal/lockfile-lint/blob/v4.14.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Liran Tal",
       "email": "liran.tal@gmail.com",
       "url": "https://github.com/lirantal"
     },
-    "nock@13.2.9": {
+    "nock@13.5.4": {
       "name": "nock",
-      "version": "13.2.9",
+      "version": "13.5.4",
       "range": "^13.1.1",
       "licenses": "MIT",
       "repoUrl": "https://github.com/nock/nock",
-      "versionedRepoUrl": "https://github.com/nock/nock/tree/v13.2.9",
+      "versionedRepoUrl": "https://github.com/nock/nock/tree/v13.5.4",
       "licenseFile": "node_modules/nock/LICENSE",
-      "licenseUrl": "https://github.com/nock/nock/blob/v13.2.9/LICENSE",
+      "licenseUrl": "https://github.com/nock/nock/blob/v13.5.4/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Pedro Teixeira",
       "email": "pedro.teixeira@gmail.com"
     },
-    "prettier@2.8.1": {
+    "prettier@2.8.8": {
       "name": "prettier",
-      "version": "2.8.1",
+      "version": "2.8.8",
       "range": "^2.3.2",
       "licenses": "MIT",
       "repoUrl": "https://github.com/prettier/prettier",
-      "versionedRepoUrl": "https://github.com/prettier/prettier/tree/v2.8.1",
+      "versionedRepoUrl": "https://github.com/prettier/prettier/tree/v2.8.8",
       "licenseFile": "node_modules/prettier/LICENSE",
-      "licenseUrl": "https://github.com/prettier/prettier/blob/v2.8.1/LICENSE",
+      "licenseUrl": "https://github.com/prettier/prettier/blob/v2.8.8/LICENSE",
       "licenseTextSource": "file",
       "publisher": "James Long"
     },
@@ -297,15 +271,15 @@
       "licenseTextSource": "file",
       "publisher": "Christian Johansen"
     },
-    "tap@16.3.7": {
+    "tap@16.3.10": {
       "name": "tap",
-      "version": "16.3.7",
+      "version": "16.3.10",
       "range": "^16.3.7",
       "licenses": "ISC",
       "repoUrl": "https://github.com/tapjs/node-tap",
-      "versionedRepoUrl": "https://github.com/tapjs/node-tap/tree/v16.3.7",
+      "versionedRepoUrl": "https://github.com/tapjs/node-tap/tree/v16.3.10",
       "licenseFile": "node_modules/tap/LICENSE",
-      "licenseUrl": "https://github.com/tapjs/node-tap/blob/v16.3.7/LICENSE",
+      "licenseUrl": "https://github.com/tapjs/node-tap/blob/v16.3.10/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Isaac Z. Schlueter",
       "email": "i@izs.me",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.
This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md
Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

Aside from dropping `node-gyp` since the version on 18+ is ok for our CI. I was able to drop `semver` because we're no longer on 16

## Related Issues

Closes #249 