### PR TITLE
chore: Added `node-gyp` v12 to dev deps to get tests to run on `windows-latest`

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -36,6 +36,7 @@ code, the source code can be found at [https://github.com/newrelic/node-native-m
 * [lint-staged](#lint-staged)
 * [lockfile-lint](#lockfile-lint)
 * [nock](#nock)
+* [node-gyp](#node-gyp)
 * [prettier](#prettier)
 * [proxyquire](#proxyquire)
 * [sinon](#sinon)
@@ -46,7 +47,7 @@ code, the source code can be found at [https://github.com/newrelic/node-native-m
 
 ### nan
 
-This product includes source derived from [nan](https://github.com/nodejs/nan) ([v2.22.2](https://github.com/nodejs/nan/tree/v2.22.2)), distributed under the [MIT License](https://github.com/nodejs/nan/blob/v2.22.2/LICENSE.md):
+This product includes source derived from [nan](https://github.com/nodejs/nan) ([v2.26.2](https://github.com/nodejs/nan/tree/v2.26.2)), distributed under the [MIT License](https://github.com/nodejs/nan/blob/v2.26.2/LICENSE.md):
 
 ```
 The MIT License (MIT)
@@ -63,7 +64,7 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ### node-gyp-build
 
-This product includes source derived from [node-gyp-build](https://github.com/prebuild/node-gyp-build) ([v4.8.4](https://github.com/prebuild/node-gyp-build/tree/v4.8.4)), distributed under the [MIT License](https://github.com/prebuild/node-gyp-build/blob/v4.8.4/LICENSE):
+This product includes source derived from [node-gyp-build](https://github.com/prebuild/node-gyp-build) ([v4.8.1](https://github.com/prebuild/node-gyp-build/tree/v4.8.1)), distributed under the [MIT License](https://github.com/prebuild/node-gyp-build/blob/v4.8.1/LICENSE):
 
 ```
 The MIT License (MIT)
@@ -584,7 +585,7 @@ THE SOFTWARE.
 
 ### aws-sdk
 
-This product includes source derived from [aws-sdk](https://github.com/aws/aws-sdk-js) ([v2.1591.0](https://github.com/aws/aws-sdk-js/tree/v2.1591.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js/blob/v2.1591.0/LICENSE.txt):
+This product includes source derived from [aws-sdk](https://github.com/aws/aws-sdk-js) ([v2.1656.0](https://github.com/aws/aws-sdk-js/tree/v2.1656.0)), distributed under the [Apache-2.0 License](https://github.com/aws/aws-sdk-js/blob/v2.1656.0/LICENSE.txt):
 
 ```
 
@@ -794,7 +795,7 @@ This product includes source derived from [aws-sdk](https://github.com/aws/aws-s
 
 ### borp
 
-This product includes source derived from [borp](https://github.com/mcollina/borp) ([v0.20.0](https://github.com/mcollina/borp/tree/v0.20.0)), distributed under the [MIT License](https://github.com/mcollina/borp/blob/v0.20.0/LICENSE):
+This product includes source derived from [borp](https://github.com/mcollina/borp) ([v0.20.2](https://github.com/mcollina/borp/tree/v0.20.2)), distributed under the [MIT License](https://github.com/mcollina/borp/blob/v0.20.2/LICENSE):
 
 ```
 MIT License
@@ -1037,7 +1038,7 @@ SOFTWARE.
 
 ### lockfile-lint
 
-This product includes source derived from [lockfile-lint](https://github.com/lirantal/lockfile-lint) ([v4.13.2](https://github.com/lirantal/lockfile-lint/tree/v4.13.2)), distributed under the [Apache-2.0 License](https://github.com/lirantal/lockfile-lint/blob/v4.13.2/LICENSE):
+This product includes source derived from [lockfile-lint](https://github.com/lirantal/lockfile-lint) ([v4.14.0](https://github.com/lirantal/lockfile-lint/tree/v4.14.0)), distributed under the [Apache-2.0 License](https://github.com/lirantal/lockfile-lint/blob/v4.14.0/LICENSE):
 
 ```
 
@@ -1259,6 +1260,38 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+```
+
+### node-gyp
+
+This product includes source derived from [node-gyp](https://github.com/nodejs/node-gyp) ([v12.3.0](https://github.com/nodejs/node-gyp/tree/v12.3.0)), distributed under the [MIT License](https://github.com/nodejs/node-gyp/blob/v12.3.0/LICENSE):
+
+```
+(The MIT License)
+
+Copyright (c) 2012 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
 
 ```
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "lint-staged": "^11.1.1",
     "lockfile-lint": "^4.9.6",
     "nock": "^13.1.1",
+    "node-gyp": "^12.3.0",
     "prettier": "^2.3.2",
     "proxyquire": "^2.1.3",
     "sinon": "^11.1.2",

--- a/third_party_manifest.json
+++ b/third_party_manifest.json
@@ -1,30 +1,30 @@
 {
-  "lastUpdated": "Tue May 13 2025 15:43:13 GMT-0400 (Eastern Daylight Time)",
+  "lastUpdated": "Tue May 05 2026 17:17:18 GMT-0400 (Eastern Daylight Time)",
   "projectName": "Native Metrics for New Relic Node Agent",
   "projectUrl": "https://github.com/newrelic/node-native-metrics",
   "includeOptDeps": false,
   "includeDev": true,
   "dependencies": {
-    "nan@2.22.2": {
+    "nan@2.26.2": {
       "name": "nan",
-      "version": "2.22.2",
+      "version": "2.26.2",
       "range": "^2.22.2",
       "licenses": "MIT",
       "repoUrl": "https://github.com/nodejs/nan",
-      "versionedRepoUrl": "https://github.com/nodejs/nan/tree/v2.22.2",
+      "versionedRepoUrl": "https://github.com/nodejs/nan/tree/v2.26.2",
       "licenseFile": "node_modules/nan/LICENSE.md",
-      "licenseUrl": "https://github.com/nodejs/nan/blob/v2.22.2/LICENSE.md",
+      "licenseUrl": "https://github.com/nodejs/nan/blob/v2.26.2/LICENSE.md",
       "licenseTextSource": "file"
     },
-    "node-gyp-build@4.8.4": {
+    "node-gyp-build@4.8.1": {
       "name": "node-gyp-build",
-      "version": "4.8.4",
+      "version": "4.8.1",
       "range": "^4.8.1",
       "licenses": "MIT",
       "repoUrl": "https://github.com/prebuild/node-gyp-build",
-      "versionedRepoUrl": "https://github.com/prebuild/node-gyp-build/tree/v4.8.4",
+      "versionedRepoUrl": "https://github.com/prebuild/node-gyp-build/tree/v4.8.1",
       "licenseFile": "node_modules/node-gyp-build/LICENSE",
-      "licenseUrl": "https://github.com/prebuild/node-gyp-build/blob/v4.8.4/LICENSE",
+      "licenseUrl": "https://github.com/prebuild/node-gyp-build/blob/v4.8.1/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Mathias Buus",
       "url": "@mafintosh"
@@ -95,28 +95,28 @@
       "licenseTextSource": "file",
       "publisher": "Caolan McMahon"
     },
-    "aws-sdk@2.1591.0": {
+    "aws-sdk@2.1656.0": {
       "name": "aws-sdk",
-      "version": "2.1591.0",
+      "version": "2.1656.0",
       "range": "^2.266.1",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/aws/aws-sdk-js",
-      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js/tree/v2.1591.0",
+      "versionedRepoUrl": "https://github.com/aws/aws-sdk-js/tree/v2.1656.0",
       "licenseFile": "node_modules/aws-sdk/LICENSE.txt",
-      "licenseUrl": "https://github.com/aws/aws-sdk-js/blob/v2.1591.0/LICENSE.txt",
+      "licenseUrl": "https://github.com/aws/aws-sdk-js/blob/v2.1656.0/LICENSE.txt",
       "licenseTextSource": "file",
       "publisher": "Amazon Web Services",
       "url": "https://aws.amazon.com/"
     },
-    "borp@0.20.0": {
+    "borp@0.20.2": {
       "name": "borp",
-      "version": "0.20.0",
+      "version": "0.20.2",
       "range": "^0.20.0",
       "licenses": "MIT",
       "repoUrl": "https://github.com/mcollina/borp",
-      "versionedRepoUrl": "https://github.com/mcollina/borp/tree/v0.20.0",
+      "versionedRepoUrl": "https://github.com/mcollina/borp/tree/v0.20.2",
       "licenseFile": "node_modules/borp/LICENSE",
-      "licenseUrl": "https://github.com/mcollina/borp/blob/v0.20.0/LICENSE",
+      "licenseUrl": "https://github.com/mcollina/borp/blob/v0.20.2/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Matteo Collina",
       "email": "hello@matteocollina.com"
@@ -221,15 +221,15 @@
       "publisher": "Andrey Okonetchnikov",
       "email": "andrey@okonet.ru"
     },
-    "lockfile-lint@4.13.2": {
+    "lockfile-lint@4.14.0": {
       "name": "lockfile-lint",
-      "version": "4.13.2",
+      "version": "4.14.0",
       "range": "^4.9.6",
       "licenses": "Apache-2.0",
       "repoUrl": "https://github.com/lirantal/lockfile-lint",
-      "versionedRepoUrl": "https://github.com/lirantal/lockfile-lint/tree/v4.13.2",
+      "versionedRepoUrl": "https://github.com/lirantal/lockfile-lint/tree/v4.14.0",
       "licenseFile": "node_modules/lockfile-lint/LICENSE",
-      "licenseUrl": "https://github.com/lirantal/lockfile-lint/blob/v4.13.2/LICENSE",
+      "licenseUrl": "https://github.com/lirantal/lockfile-lint/blob/v4.14.0/LICENSE",
       "licenseTextSource": "file",
       "publisher": "Liran Tal",
       "email": "liran.tal@gmail.com",
@@ -247,6 +247,20 @@
       "licenseTextSource": "file",
       "publisher": "Pedro Teixeira",
       "email": "pedro.teixeira@gmail.com"
+    },
+    "node-gyp@12.3.0": {
+      "name": "node-gyp",
+      "version": "12.3.0",
+      "range": "^12.3.0",
+      "licenses": "MIT",
+      "repoUrl": "https://github.com/nodejs/node-gyp",
+      "versionedRepoUrl": "https://github.com/nodejs/node-gyp/tree/v12.3.0",
+      "licenseFile": "node_modules/node-gyp/LICENSE",
+      "licenseUrl": "https://github.com/nodejs/node-gyp/blob/v12.3.0/LICENSE",
+      "licenseTextSource": "file",
+      "publisher": "Nathan Rajlich",
+      "email": "nathan@tootallnate.net",
+      "url": "http://tootallnate.net"
     },
     "prettier@2.8.8": {
       "name": "prettier",


### PR DESCRIPTION
…

<!--
Thank you for submitting a Pull Request.
This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.
Ensure that your Pull Request title adheres to our Conventional Commit standards
as described in CONTRIBUTING.md
Please update the Pull Request description to add relevant context or documentation about
the submitted change.
-->
## Description

The image for `windows-latest` changed and `node-gyp` 11 no longer works with it. This PR adds `node-gyp` as a dev dep to be used for `node-gyp-build` on windows.
