### PR TITLE
chore: Specified Node version tag for publishing

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -161,6 +161,7 @@ jobs:
           path: agent-repo
       - uses: actions/setup-node@v6
         with:
+          node-version: 'lts/*'
           check-latest: true
       - run: |
           # Install agent-repo dependencies.
@@ -191,8 +192,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v6
         with:
-          # Required minimum Node version for Trusted Publishing is 24.5.0.
-          node-version: 24.x
+          node-version: 'lts/*'
           registry-url: 'https://registry.npmjs.org'
           check-latest: true
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
Evidently the "fix" in #301 was not sufficient (https://github.com/newrelic/node-native-metrics/actions/runs/28451927022/workflow#L162-L164).